### PR TITLE
Add week day modeling and wire up entry form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bootsnap', require: false
 gem 'coffee-rails'
 gem 'decent_exposure'
 gem 'devise'
+gem 'forty_time'
 gem 'haml'
 gem 'jbuilder'
 gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       railties (>= 4.2.0)
     ffi (1.12.2)
     formatador (0.2.5)
+    forty_time (0.0.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.16.1)
@@ -322,6 +323,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_bot_rails
+  forty_time
   guard-livereload
   haml
   jbuilder

--- a/app/controllers/today_controller.rb
+++ b/app/controllers/today_controller.rb
@@ -1,6 +1,6 @@
 class TodayController < ApplicationController
-  before_action :authenticate_user!
-  expose(:props) do
-    { dates: 'Feb 17-21, 2020' }
+  def show
+    today_target = Time.zone.today.strftime('%Y-%V')
+    redirect_to "/work_weeks/#{today_target}"
   end
 end

--- a/app/controllers/work_days_controller.rb
+++ b/app/controllers/work_days_controller.rb
@@ -1,0 +1,20 @@
+class WorkDaysController < ApplicationController
+  before_action :authenticate_user!
+
+  expose(:work_day, scope: -> { current_user.work_days })
+
+  def update
+    if work_day.update(work_day_params)
+      render json: work_day
+    else
+      head :bad_request
+    end
+  end
+
+  private
+
+  def work_day_params
+    permitted_fields = %i[adjust_minutes in_minutes out_minutes pto_minutes]
+    params.require(:work_day).permit(permitted_fields)
+  end
+end

--- a/app/controllers/work_weeks_controller.rb
+++ b/app/controllers/work_weeks_controller.rb
@@ -1,0 +1,15 @@
+class WorkWeeksController < ApplicationController
+  before_action :authenticate_user!
+
+  expose(:work_week) do
+    year, number = params[:target].split('-')
+    WorkWeek.find_or_create_by(user: current_user, year: year, number: number)
+  end
+
+  expose(:props) do
+    {
+      dates: 'Feb 17-21, 2020',
+      workWeek: work_week
+    }
+  end
+end

--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -1,10 +1,56 @@
 import React from "react"
 import { mount } from "enzyme"
-import { WeekEntry } from "./"
+import { WeekEntry, WeekEntryProps } from "./"
+
+const defaultWorkDays = [
+  {
+    adjustMinutes: 0,
+    dayOfWeek: "Monday",
+    inMinutes: 540,
+    outMinutes: 1020,
+    ptoMinutes: 0
+  },
+  {
+    adjustMinutes: 0,
+    dayOfWeek: "Tuesday",
+    inMinutes: 540,
+    outMinutes: 1020,
+    ptoMinutes: 0
+  },
+  {
+    adjustMinutes: 0,
+    dayOfWeek: "Wednesday",
+    inMinutes: 540,
+    outMinutes: 1020,
+    ptoMinutes: 0
+  },
+  {
+    adjustMinutes: 0,
+    dayOfWeek: "Thursday",
+    inMinutes: 540,
+    outMinutes: 1020,
+    ptoMinutes: 0
+  },
+  {
+    adjustMinutes: 0,
+    dayOfWeek: "Friday",
+    inMinutes: 540,
+    outMinutes: 1020,
+    ptoMinutes: 0
+  }
+]
+
+const defaultProps: WeekEntryProps = {
+  dates: "Feb 17-21, 2020",
+  workWeek: { workDays: defaultWorkDays }
+}
 
 describe("WeekEntry", () => {
   it("renders 5 columns", () => {
-    const wrapper = mount(<WeekEntry />)
+    const props = {
+      ...defaultProps
+    }
+    const wrapper = mount(<WeekEntry {...props} />)
     expect(wrapper.find("WeekColumn")).toHaveLength(5)
   })
 })

--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -1,11 +1,13 @@
 import React from "react"
 import { mount } from "enzyme"
 import { WeekEntry, WeekEntryProps } from "./"
+import { WeekEntryFetcher } from "./WeekEntryFetcher"
 
 const defaultWorkDays = [
   {
     adjustMinutes: 0,
     dayOfWeek: "Monday",
+    id: 1,
     inMinutes: 540,
     outMinutes: 1020,
     ptoMinutes: 0
@@ -13,6 +15,7 @@ const defaultWorkDays = [
   {
     adjustMinutes: 0,
     dayOfWeek: "Tuesday",
+    id: 2,
     inMinutes: 540,
     outMinutes: 1020,
     ptoMinutes: 0
@@ -20,6 +23,7 @@ const defaultWorkDays = [
   {
     adjustMinutes: 0,
     dayOfWeek: "Wednesday",
+    id: 3,
     inMinutes: 540,
     outMinutes: 1020,
     ptoMinutes: 0
@@ -27,6 +31,7 @@ const defaultWorkDays = [
   {
     adjustMinutes: 0,
     dayOfWeek: "Thursday",
+    id: 4,
     inMinutes: 540,
     outMinutes: 1020,
     ptoMinutes: 0
@@ -34,14 +39,19 @@ const defaultWorkDays = [
   {
     adjustMinutes: 0,
     dayOfWeek: "Friday",
+    id: 5,
     inMinutes: 540,
     outMinutes: 1020,
     ptoMinutes: 0
   }
 ]
 
+const mockFetcher: WeekEntryFetcher = new WeekEntryFetcher("invalid")
+mockFetcher.updateWorkDay = jest.fn()
+
 const defaultProps: WeekEntryProps = {
   dates: "Feb 17-21, 2020",
+  fetcher: mockFetcher,
   workWeek: { workDays: defaultWorkDays }
 }
 

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -1,16 +1,39 @@
 import React from "react"
-import { WeekColumn } from "./components/WeekColumn"
+import { WeekColumn, WorkDayData } from "./components/WeekColumn"
+import { FortyTime } from "forty-time"
 
-const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+interface WorkDay {
+  adjustMinutes: number
+  dayOfWeek: string
+  inMinutes: number
+  outMinutes: number
+  ptoMinutes: number
+}
+
+interface WorkWeek {
+  workDays: WorkDay[]
+}
 
 export interface WeekEntryProps {
   dates: string
+  workWeek: WorkWeek
+}
+
+const computeWorkDayData = (workDay: WorkDay): WorkDayData => {
+  return {
+    adjustAmount: FortyTime.parse(workDay.adjustMinutes).toString(),
+    dayOfWeek: workDay.dayOfWeek,
+    inTime: FortyTime.parse(workDay.inMinutes).toString(),
+    outTime: FortyTime.parse(workDay.outMinutes).toString(),
+    ptoAmount: FortyTime.parse(workDay.ptoMinutes).toString()
+  }
 }
 
 export const WeekEntry: React.FC<WeekEntryProps> = props => {
-  const { dates } = props
-  const weekColumns = days.map((day, index) => {
-    return <WeekColumn key={index} day={day} />
+  const { dates, workWeek } = props
+  const weekColumns = workWeek.workDays.map((workDay, index) => {
+    const workDayData = computeWorkDayData(workDay)
+    return <WeekColumn key={index} workDay={workDayData} />
   })
   return (
     <>

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -1,10 +1,12 @@
 import React from "react"
 import { WeekColumn, WorkDayData } from "./components/WeekColumn"
+import { WeekEntryFetcher } from "./WeekEntryFetcher"
 import { FortyTime } from "forty-time"
 
 interface WorkDay {
   adjustMinutes: number
   dayOfWeek: string
+  id: number
   inMinutes: number
   outMinutes: number
   ptoMinutes: number
@@ -16,6 +18,7 @@ interface WorkWeek {
 
 export interface WeekEntryProps {
   dates: string
+  fetcher: WeekEntryFetcher
   workWeek: WorkWeek
 }
 
@@ -23,6 +26,7 @@ const computeWorkDayData = (workDay: WorkDay): WorkDayData => {
   return {
     adjustAmount: FortyTime.parse(workDay.adjustMinutes).toString(),
     dayOfWeek: workDay.dayOfWeek,
+    id: workDay.id,
     inTime: FortyTime.parse(workDay.inMinutes).toString(),
     outTime: FortyTime.parse(workDay.outMinutes).toString(),
     ptoAmount: FortyTime.parse(workDay.ptoMinutes).toString()
@@ -31,10 +35,23 @@ const computeWorkDayData = (workDay: WorkDay): WorkDayData => {
 
 export const WeekEntry: React.FC<WeekEntryProps> = props => {
   const { dates, workWeek } = props
-  const weekColumns = workWeek.workDays.map((workDay, index) => {
+
+  const handleWorkDayUpdate = (id, key, value): void => {
+    const body = { [key]: value }
+    props.fetcher.updateWorkDay(id, body)
+  }
+
+  const weekColumns = workWeek.workDays.map(workDay => {
     const workDayData = computeWorkDayData(workDay)
-    return <WeekColumn key={index} workDay={workDayData} />
+    return (
+      <WeekColumn
+        handleWorkDayUpdate={handleWorkDayUpdate}
+        key={workDay.id}
+        workDay={workDayData}
+      />
+    )
   })
+
   return (
     <>
       <h1>{dates}</h1>

--- a/app/javascript/apps/WeekEntry/WeekEntryFetcher.ts
+++ b/app/javascript/apps/WeekEntry/WeekEntryFetcher.ts
@@ -1,0 +1,8 @@
+import { BaseFetcher, ResponseJson } from "../../shared/BaseFetcher"
+
+export class WeekEntryFetcher extends BaseFetcher {
+  updateWorkDay = (id, body): ResponseJson => {
+    const url = `/work_days/${id}.json`
+    return this.sendRequest(url, "PATCH", body)
+  }
+}

--- a/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.spec.tsx
+++ b/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.spec.tsx
@@ -2,10 +2,22 @@ import React from "react"
 import { mount } from "enzyme"
 import { WeekColumn, WeekColumnProps } from "./"
 
+const defaultWorkDay = {
+  adjustAmount: "0:00",
+  dayOfWeek: "Monday",
+  inTime: "8:00",
+  outTime: "17:00",
+  ptoAmount: "0:00"
+}
+
+const defaultProps: WeekColumnProps = {
+  workDay: defaultWorkDay
+}
+
 describe("WeekColumn", () => {
   it("renders a bunch of inputs", () => {
     const props: WeekColumnProps = {
-      day: "Monday"
+      ...defaultProps
     }
     const wrapper = mount(<WeekColumn {...props} />)
     expect(wrapper.find("input")).toHaveLength(4)

--- a/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
+++ b/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
@@ -1,14 +1,17 @@
 import React, { useState } from "react"
+import { FortyTime } from "forty-time"
 
 export interface WorkDayData {
   adjustAmount: string
   dayOfWeek: string
+  id: number
   inTime: string
   outTime: string
   ptoAmount: string
 }
 
 export interface WeekColumnProps {
+  handleWorkDayUpdate: (id, key, value) => void
   workDay: WorkDayData
 }
 
@@ -46,6 +49,8 @@ export const WeekColumn: React.FC<WeekColumnProps> = props => {
       adjustAmount
     )
     setTotalTime(newTotal)
+    const inMinutes = FortyTime.parse(newInTime).minutes
+    props.handleWorkDayUpdate(workDay.id, "in_minutes", inMinutes)
   }
 
   const handleOutTimeChange = (e): void => {
@@ -58,6 +63,8 @@ export const WeekColumn: React.FC<WeekColumnProps> = props => {
       adjustAmount
     )
     setTotalTime(newTotal)
+    const outMinutes = FortyTime.parse(newOutTime).minutes
+    props.handleWorkDayUpdate(workDay.id, "out_minutes", outMinutes)
   }
 
   const handlePtoAmountChange = (e): void => {
@@ -70,6 +77,8 @@ export const WeekColumn: React.FC<WeekColumnProps> = props => {
       adjustAmount
     )
     setTotalTime(newTotal)
+    const ptoMinutes = FortyTime.parse(newPtoAmount).minutes
+    props.handleWorkDayUpdate(workDay.id, "pto_minutes", ptoMinutes)
   }
 
   const handleAdjustAmountChange = (e): void => {
@@ -82,6 +91,8 @@ export const WeekColumn: React.FC<WeekColumnProps> = props => {
       newAdjustAmount
     )
     setTotalTime(newTotal)
+    const adjustMinutes = FortyTime.parse(newAdjustAmount).minutes
+    props.handleWorkDayUpdate(workDay.id, "adjust_minutes", adjustMinutes)
   }
 
   return (

--- a/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
+++ b/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
@@ -1,7 +1,15 @@
 import React, { useState } from "react"
 
+export interface WorkDayData {
+  adjustAmount: string
+  dayOfWeek: string
+  inTime: string
+  outTime: string
+  ptoAmount: string
+}
+
 export interface WeekColumnProps {
-  day: string
+  workDay: WorkDayData
 }
 
 const computeTotalTime = (
@@ -19,12 +27,13 @@ const computeTotalTime = (
 }
 
 export const WeekColumn: React.FC<WeekColumnProps> = props => {
-  const { day } = props
+  const { workDay } = props
+  const day = workDay.dayOfWeek
 
-  const [inTime, setInTime] = useState("0:00")
-  const [outTime, setOutTime] = useState("0:00")
-  const [ptoAmount, setPtoAmount] = useState("0:00")
-  const [adjustAmount, setAdjustAmount] = useState("0:00")
+  const [inTime, setInTime] = useState(workDay.inTime)
+  const [outTime, setOutTime] = useState(workDay.outTime)
+  const [ptoAmount, setPtoAmount] = useState(workDay.ptoAmount)
+  const [adjustAmount, setAdjustAmount] = useState(workDay.adjustAmount)
   const [totalTime, setTotalTime] = useState(0)
 
   const handleInTimeChange = (e): void => {
@@ -83,24 +92,28 @@ export const WeekColumn: React.FC<WeekColumnProps> = props => {
         name={`${day.toLowerCase()}_in`}
         placeholder="in"
         type="text"
+        value={inTime}
       />
       <input
         onChange={handleOutTimeChange}
         name={`${day.toLowerCase()}_out`}
         placeholder="out"
         type="text"
+        value={outTime}
       />
       <input
         onChange={handlePtoAmountChange}
         name={`${day.toLowerCase()}_pto`}
         placeholder="pto"
         type="text"
+        value={ptoAmount}
       />
       <input
         onChange={handleAdjustAmountChange}
         name={`${day.toLowerCase()}_adjust`}
         placeholder="adjust"
         type="text"
+        value={adjustAmount}
       />
       <p className={`${day.toLowerCase()}_total total`}>{`${totalTime}:00`}</p>
     </section>

--- a/app/javascript/packs/week_entry.tsx
+++ b/app/javascript/packs/week_entry.tsx
@@ -1,9 +1,20 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import { WeekEntry, WeekEntryProps } from "../apps/WeekEntry"
+import { WeekEntryFetcher } from "../apps/WeekEntry/WeekEntryFetcher"
 
 document.addEventListener("DOMContentLoaded", () => {
   const root = document.getElementById("week_entry_root")
-  const props: WeekEntryProps = JSON.parse(root.dataset.props)
+  const parsedProps = JSON.parse(root.dataset.props)
+
+  const metaTag = document.querySelector("meta[name=csrf-token]")
+  const token = metaTag && metaTag.getAttribute("content")
+  const fetcher = new WeekEntryFetcher(token)
+
+  const props: WeekEntryProps = {
+    ...parsedProps,
+    fetcher
+  }
+
   ReactDOM.render(<WeekEntry {...props} />, root)
 })

--- a/app/javascript/shared/BaseFetcher.ts
+++ b/app/javascript/shared/BaseFetcher.ts
@@ -1,0 +1,45 @@
+export type RequestBody = object | object[]
+export type ResponseJson = Promise<object | object[]>
+
+const jsonContentType = "application/json"
+
+export class BaseFetcher {
+  token: string
+
+  constructor(token: string) {
+    this.token = token
+  }
+
+  sendRequest = (
+    url: string,
+    method: string,
+    body?: RequestBody
+  ): ResponseJson => {
+    const headers = {
+      Accept: jsonContentType,
+      "Content-Type": "application/json",
+      "X-CSRF-TOKEN": this.token
+    }
+
+    const credentials: RequestCredentials = "same-origin"
+
+    const options = {
+      body: JSON.stringify(body),
+      credentials,
+      headers,
+      method
+    }
+
+    return fetch(url, options).then(response => {
+      if (!response.ok) throw new Error("non 200 response")
+
+      const contentType = response.headers.get("Content-Type")
+
+      if (contentType && contentType.match(jsonContentType)) {
+        return response.json()
+      } else {
+        return response.text()
+      }
+    })
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :recoverable,
          :registerable, :rememberable, :validatable
+
+  has_many :work_days, dependent: :destroy
 end

--- a/app/models/work_day.rb
+++ b/app/models/work_day.rb
@@ -3,7 +3,7 @@ class WorkDay < ApplicationRecord
   validates :date, presence: true, uniqueness: { scope: :user_id }
   delegate :year, to: :date
 
-  def as_json
+  def as_json(*_)
     {
       adjustMinutes: adjust_minutes,
       dayOfWeek: date.strftime('%A'),

--- a/app/models/work_day.rb
+++ b/app/models/work_day.rb
@@ -1,0 +1,5 @@
+class WorkDay < ApplicationRecord
+  belongs_to :user
+  validates :date, presence: true, uniqueness: { scope: :user_id }
+  delegate :year, to: :date
+end

--- a/app/models/work_day.rb
+++ b/app/models/work_day.rb
@@ -2,4 +2,15 @@ class WorkDay < ApplicationRecord
   belongs_to :user
   validates :date, presence: true, uniqueness: { scope: :user_id }
   delegate :year, to: :date
+
+  def as_json
+    {
+      adjustMinutes: adjust_minutes,
+      dayOfWeek: date.strftime('%A'),
+      id: id,
+      inMinutes: in_minutes,
+      outMinutes: out_minutes,
+      ptoMinutes: pto_minutes
+    }
+  end
 end

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -15,6 +15,7 @@ class WorkWeek
     @user = user
     @year = year.to_i
     @number = number.to_i
+    @work_days = []
   end
 
   def find_or_create
@@ -23,12 +24,18 @@ class WorkWeek
     end
   end
 
+  def as_json(_)
+    {
+      workDays: @work_days
+    }
+  end
+
   private
 
   def dates
     raise InvalidDates unless @year.positive? && @number.positive?
 
-    (1..5).map { |day| Date.commercial(@year, @number, day) }
+    @dates ||= (1..5).map { |day| Date.commercial(@year, @number, day) }
   rescue StandardError
     raise InvalidDates
   end

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -1,0 +1,35 @@
+class WorkWeek
+  class InvalidDates < StandardError; end
+
+  attr_reader :work_days
+
+  def self.find_or_create_by(user:, year:, number:)
+    work_week = new(user, year, number)
+    work_week.find_or_create
+    work_week
+  rescue InvalidDates # rubocop:disable Lint/SuppressedException
+    # year and/or number failed to parse as valid date
+  end
+
+  def initialize(user, year, number)
+    @user = user
+    @year = year.to_i
+    @number = number.to_i
+  end
+
+  def find_or_create
+    @work_days = dates.map do |date|
+      @user.work_days.find_or_create_by!(date: date)
+    end
+  end
+
+  private
+
+  def dates
+    raise InvalidDates unless @year.positive? && @number.positive?
+
+    (1..5).map { |day| Date.commercial(@year, @number, day) }
+  rescue StandardError
+    raise InvalidDates
+  end
+end

--- a/app/views/today/show.html.haml
+++ b/app/views/today/show.html.haml
@@ -1,2 +1,0 @@
-#week_entry_root{ data: { props: props.to_json } }
-= javascript_pack_tag 'week_entry'

--- a/app/views/work_weeks/show.html.haml
+++ b/app/views/work_weeks/show.html.haml
@@ -1,0 +1,2 @@
+#week_entry_root{ data: { props: props.to_json } }
+= javascript_pack_tag 'week_entry'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,7 @@ Rails.application.routes.draw do
   get :ping, to: 'ping#show'
   get :today, to: 'today#show'
 
+  get 'work_weeks/:target', to: 'work_weeks#show'
+
   root to: redirect('/today')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,7 @@ Rails.application.routes.draw do
 
   get 'work_weeks/:target', to: 'work_weeks#show'
 
+  patch 'work_days/:id', to: 'work_days#update'
+
   root to: redirect('/today')
 end

--- a/db/migrate/20200314020709_add_work_days.rb
+++ b/db/migrate/20200314020709_add_work_days.rb
@@ -1,0 +1,15 @@
+class AddWorkDays < ActiveRecord::Migration[6.0]
+  def change
+    create_table :work_days do |t|
+      t.belongs_to :user
+      t.date :date, null: false
+      t.integer :adjust_minutes, default: 0, null: false
+      t.integer :in_minutes, default: 0, null: false
+      t.integer :out_minutes, default: 0, null: false
+      t.integer :pto_minutes, default: 0, null: false
+      t.timestamps
+    end
+
+    add_index :work_days, %i[date user_id], unique: true
+  end
+end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "babel-plugin-module-resolver": "^4.0.0",
+    "forty-time": "^0.0.3",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "ts-loader": "^6.2.1",

--- a/spec/factories/work_day.rb
+++ b/spec/factories/work_day.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :work_day do
+    date { Time.zone.today }
+  end
+end

--- a/spec/models/work_day_spec.rb
+++ b/spec/models/work_day_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe WorkDay do
+  describe 'uniqueness' do
+    context 'attempting to create a duplicate work day for a user' do
+      it 'is invalid' do
+        user = FactoryBot.create :user
+        date = '2017-01-01'
+
+        FactoryBot.create :work_day, user: user, date: date
+
+        duplicate_work_day = FactoryBot.build :work_day, user: user, date: date
+
+        expect(duplicate_work_day).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/work_week_spec.rb
+++ b/spec/models/work_week_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe WorkWeek do
+  describe '.find_or_create_by' do
+    let(:user) { FactoryBot.create :user }
+
+    context 'with an invalid year' do
+      it 'returns nil' do
+        attrs = { user: user, year: 'asdf', number: '1' }
+        work_week = WorkWeek.find_or_create_by(attrs)
+        expect(work_week).to be_nil
+      end
+    end
+
+    context 'with an invalid number' do
+      it 'returns nil' do
+        attrs = { user: user, year: '2017', number: 'asdf' }
+        work_week = WorkWeek.find_or_create_by(attrs)
+        expect(work_week).to be_nil
+      end
+    end
+
+    context 'with an existing year and number' do
+      it 'returns a WorkWeek with those existing WorkDay records' do
+        monday = FactoryBot.create :work_day, user: user, date: '2017-01-02'
+        tuesday = FactoryBot.create :work_day, user: user, date: '2017-01-03'
+        wednesday = FactoryBot.create :work_day, user: user, date: '2017-01-04'
+        thursday = FactoryBot.create :work_day, user: user, date: '2017-01-05'
+        friday = FactoryBot.create :work_day, user: user, date: '2017-01-06'
+
+        attrs = { user: user, year: '2017', number: '1' }
+        work_week = WorkWeek.find_or_create_by(attrs)
+
+        expect(WorkDay.count).to eq 5
+        expect(work_week.work_days).to eq(
+          [
+            monday,
+            tuesday,
+            wednesday,
+            thursday,
+            friday
+          ]
+        )
+      end
+    end
+
+    context 'with a new year and number' do
+      it 'creates WorkDay records and returns a WorkWeek for them' do
+        expect(WorkDay.count).to eq 0
+        attrs = { user: user, year: '2017', number: '1' }
+        work_week = WorkWeek.find_or_create_by(attrs)
+        expect(WorkDay.count).to eq 5
+        dates = work_week.work_days.map(&:date).map(&:to_s)
+        expect(dates).to eq(
+          %w[
+            2017-01-02
+            2017-01-03
+            2017-01-04
+            2017-01-05
+            2017-01-06
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/system/user_signs_in_spec.rb
+++ b/spec/system/user_signs_in_spec.rb
@@ -7,6 +7,6 @@ describe 'User signs in' do
     fill_in 'user[email]', with: user.email
     fill_in 'user[password]', with: user.password
     click_button 'Log in'
-    expect(current_path).to eq today_path
+    expect(current_path).to match 'work_weeks'
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,6 +4028,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+forty-time@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/forty-time/-/forty-time-0.0.3.tgz#b1cb6499d1dc036306ed93e6e351b68797b49a70"
+  integrity sha512-D1BmT6tGiI0h3fy7+lQj0avxVrSI+d5ffXfTFc28roGySQ1LrYBYPptj1H5KpUXGwIZY2kV2NdOe8391O9vOzA==
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"


### PR DESCRIPTION
This PR adds persistence and then wires it up to the entry form I've been working on. I stole a bunch of code from Monolithium since I had solved many of these problems already over there and then I just adapted to the patterns I've been using here.

Along the way I also created FortyTime libraries so that I could be sure both my Ruby and Typescript code was using the same approach to working with converting integers to times and back.

Note: totals and the grand total and other parts of the app are still broken, but this is a huge step in the right direction because it allows me to start thinking about migrating data over to this app and actually living on it! 🎉 