### PR TITLE
Week entry navigation

### DIFF
--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -23,7 +23,7 @@ body
   ::selection
     background-color: $middle-green
 
-  textarea, select, input, button
+  a, button, input, select, textarea
     outline: none
 
   a
@@ -57,6 +57,29 @@ body
 
     main
       #week_entry_root
+        nav
+          display: flex
+          flex-direction: column
+          justify-content: center
+          text-align: right
+          padding-bottom: 30px
+
+          p
+            font-size: 20px
+          a
+            color: $off-black
+            background: $middle-gray
+            font-size: 16px
+            margin-left: 20px
+            padding: 4px 20px
+            text-decoration: none
+            transition: background-color $transition-config
+            transition: color $transition-config
+
+            &:hover, &:focus
+              background: $off-black
+              color: $bright-white
+
         .table
           display: flex
           flex-direction: row

--- a/app/controllers/today_controller.rb
+++ b/app/controllers/today_controller.rb
@@ -1,6 +1,6 @@
 class TodayController < ApplicationController
   def show
-    target = Time.zone.today.strftime('%Y-%V')
+    target = TargetSlug.for(Time.zone.today)
     redirect_to work_week_path(target)
   end
 end

--- a/app/controllers/today_controller.rb
+++ b/app/controllers/today_controller.rb
@@ -1,6 +1,6 @@
 class TodayController < ApplicationController
   def show
-    today_target = Time.zone.today.strftime('%Y-%V')
-    redirect_to "/work_weeks/#{today_target}"
+    target = Time.zone.today.strftime('%Y-%V')
+    redirect_to work_week_path(target)
   end
 end

--- a/app/controllers/work_weeks_controller.rb
+++ b/app/controllers/work_weeks_controller.rb
@@ -8,7 +8,6 @@ class WorkWeeksController < ApplicationController
 
   expose(:props) do
     {
-      dates: 'Feb 17-21, 2020',
       workWeek: work_week
     }
   end

--- a/app/controllers/work_weeks_controller.rb
+++ b/app/controllers/work_weeks_controller.rb
@@ -8,7 +8,29 @@ class WorkWeeksController < ApplicationController
 
   expose(:props) do
     {
+      lastWeekPath: last_week_path,
+      nextWeekPath: next_week_path,
+      thisWeekPath: this_week_path,
       workWeek: work_week
     }
+  end
+
+  private
+
+  def last_week_path
+    target_date = work_week.target_date - 1.week
+    target = TargetSlug.for(target_date)
+    work_week_path(target)
+  end
+
+  def next_week_path
+    target_date = work_week.target_date + 1.week
+    target = TargetSlug.for(target_date)
+    work_week_path(target)
+  end
+
+  def this_week_path
+    target = TargetSlug.for(Time.zone.today)
+    work_week_path(target)
   end
 end

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { WeekColumn, WorkDayData } from "./components/WeekColumn"
+import { Header } from "./components/Header"
 import { WeekEntryFetcher } from "./WeekEntryFetcher"
 import { FortyTime } from "forty-time"
 
@@ -12,12 +13,12 @@ interface WorkDay {
   ptoMinutes: number
 }
 
-interface WorkWeek {
+export interface WorkWeek {
+  dateSpan: string
   workDays: WorkDay[]
 }
 
 export interface WeekEntryProps {
-  dates: string
   fetcher: WeekEntryFetcher
   workWeek: WorkWeek
 }
@@ -34,7 +35,7 @@ const computeWorkDayData = (workDay: WorkDay): WorkDayData => {
 }
 
 export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
-  const { dates, workWeek } = props
+  const { workWeek } = props
 
   const handleWorkDayUpdate = (id, key, value): void => {
     const body = { [key]: value }
@@ -54,7 +55,9 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
 
   return (
     <>
-      <h1>{dates}</h1>
+      <Header
+        dateSpan={workWeek.dateSpan}
+      />
       <div className="table">{weekColumns}</div>
     </>
   )

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -20,6 +20,9 @@ export interface WorkWeek {
 
 export interface WeekEntryProps {
   fetcher: WeekEntryFetcher
+  lastWeekPath: string
+  nextWeekPath: string
+  thisWeekPath: string
   workWeek: WorkWeek
 }
 
@@ -35,7 +38,7 @@ const computeWorkDayData = (workDay: WorkDay): WorkDayData => {
 }
 
 export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
-  const { workWeek } = props
+  const { lastWeekPath, nextWeekPath, thisWeekPath, workWeek } = props
 
   const handleWorkDayUpdate = (id, key, value): void => {
     const body = { [key]: value }
@@ -57,6 +60,9 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
     <>
       <Header
         dateSpan={workWeek.dateSpan}
+        lastWeekPath={lastWeekPath}
+        nextWeekPath={nextWeekPath}
+        thisWeekPath={thisWeekPath}
       />
       <div className="table">{weekColumns}</div>
     </>

--- a/app/javascript/apps/WeekEntry/components/Header/Header.tsx
+++ b/app/javascript/apps/WeekEntry/components/Header/Header.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+export interface HeaderProps {
+  dateSpan: string
+}
+
+export const Header: React.FC<HeaderProps> = props => {
+  const { dateSpan } = props
+
+  return (
+    <nav>
+      <p>{dateSpan}</p>
+    </nav>
+  )
+}

--- a/app/javascript/apps/WeekEntry/components/Header/Header.tsx
+++ b/app/javascript/apps/WeekEntry/components/Header/Header.tsx
@@ -2,14 +2,22 @@ import React from "react"
 
 export interface HeaderProps {
   dateSpan: string
+  lastWeekPath: string
+  nextWeekPath: string
+  thisWeekPath: string
 }
 
-export const Header: React.FC<HeaderProps> = props => {
-  const { dateSpan } = props
+export const Header: React.FC<HeaderProps> = (props) => {
+  const { dateSpan, lastWeekPath, nextWeekPath, thisWeekPath } = props
 
   return (
     <nav>
       <p>{dateSpan}</p>
+      <div>
+        <a href={lastWeekPath}>&lt;</a>
+        <a href={thisWeekPath}>this week</a>
+        <a href={nextWeekPath}>&gt;</a>
+      </div>
     </nav>
   )
 }

--- a/app/javascript/apps/WeekEntry/components/Header/index.tsx
+++ b/app/javascript/apps/WeekEntry/components/Header/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Header"

--- a/app/models/target_slug.rb
+++ b/app/models/target_slug.rb
@@ -1,0 +1,7 @@
+class TargetSlug
+  def self.for(date)
+    year = date.cwyear
+    week = date.strftime('%V')
+    [year, week].join('-')
+  end
+end

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -26,11 +26,18 @@ class WorkWeek
 
   def as_json(_)
     {
+      dateSpan: date_span,
       workDays: @work_days
     }
   end
 
   private
+
+  def date_span
+    monday = dates.first
+    friday = dates.last
+    (monday..friday).to_s(:date_span)
+  end
 
   def dates
     raise InvalidDates unless @year.positive? && @number.positive?

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -31,6 +31,10 @@ class WorkWeek
     }
   end
 
+  def target_date
+    dates.first
+  end
+
   private
 
   def date_span

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,14 @@
+Range::RANGE_FORMATS.merge!(
+  date_span: proc do |start, stop|
+    same_year = start.year == stop.year
+    same_month = start.month == stop.month
+
+    rhs_format = same_month ? '%d, %Y' : '%b %d, %Y'
+    rhs = stop.strftime(rhs_format)
+
+    lhs_format = same_year ? '%b %d' : '%b %d, %Y'
+    lhs = start.strftime(lhs_format)
+
+    [lhs, rhs].join('-')
+  end
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   get :ping, to: 'ping#show'
   get :today, to: 'today#show'
 
-  get 'work_weeks/:target', to: 'work_weeks#show'
+  get 'work_weeks/:target', to: 'work_weeks#show', as: :work_week
 
   patch 'work_days/:id', to: 'work_days#update'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,8 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.before(:each, type: :system) do
     config.include Warden::Test::Helpers
     Capybara.server = :puma, { Silent: true }

--- a/spec/system/week_entry/navigation_spec.rb
+++ b/spec/system/week_entry/navigation_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'Week Entry Navigation', js: true do
+  before { travel_to(Time.zone.local(2020, 1, 7)) }
+  after { travel_back }
+
+  it 'moves from week to week' do
+    last_week_path = work_week_path('2020-01')
+    this_week_path = work_week_path('2020-02')
+    next_week_path = work_week_path('2020-03')
+
+    user = FactoryBot.create(:user)
+    login_as(user, scope: :user)
+    visit this_week_path
+
+    within('main nav') do
+      click_link '>'
+      expect(page).to have_current_path(next_week_path)
+      expect(page).to have_css('p', text: 'Jan 13-17, 2020')
+    end
+
+    within('main nav') do
+      click_link 'this week'
+      expect(page).to have_current_path(this_week_path)
+      expect(page).to have_css('p', text: 'Jan 06-10, 2020')
+    end
+
+    within('main nav') do
+      click_link '<'
+      expect(page).to have_current_path(last_week_path)
+      expect(page).to have_css('p', text: 'Dec 30, 2019-Jan 03, 2020')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds navigation to the week entry page and it looks like this:

<img width="1312" alt="Screen Shot 2020-04-12 at 4 18 20 PM" src="https://user-images.githubusercontent.com/79799/79080458-a1f31a80-7cda-11ea-964f-2a6808a9fe87.png">

I took the design from the comp captured on this one: https://github.com/verynicecode/forty-web/pull/35 and then just updated the look a bit based on my colors.

In terms of code, nothing too interesting here but I will point out a few things that I thought were neat.

## Target slug

I realized that I had some bugs at the edges of how I compute the today redirect and the computation of previous and next links. Check this out:

```ruby
> Date.parse('2019-12-30').cweek
=> 1
```

So this means that the first week of 2020 includes days from 2019. So I can use `cweek`, but I can't use the year of that date to compute a target, instead I need to use `cwyear`:

```ruby
> date = Date.parse('2019-12-30')
=> Mon, 30 Dec 2019
> date.cweek
=> 1
> date.year
=> 2019
> date.cwyear
=> 2020
```

So this realization lead to the extraction of the `TargetSlug` class. It's now the place where I store this knowledge and it just takes a date.

## Date range formatting

In order to show the date span above the links I wrote up a format for a date range that I can use like this:

```ruby
(start_date..end_date).to_s(:date_span)
```

This will trigger the logic in my custom formatter to kick in and deal with the various cases. I have this added in the initializer in `config/initializers/date_formats.rb`.