### PR TITLE
Refactor week entry to centralize computation

### DIFF
--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -1,48 +1,42 @@
 import React from "react"
 import { mount } from "enzyme"
-import { WeekEntry, WeekEntryProps } from "./"
+import { WeekEntry, WeekEntryProps, WorkDay } from "./"
 import { WeekEntryFetcher } from "./WeekEntryFetcher"
+import { FortyTime } from "forty-time"
 
-const defaultWorkDays = [
+export const defaultDay = {
+  adjustTime: FortyTime.parse(0),
+  inTime: FortyTime.parse(540),
+  outTime: FortyTime.parse(1020),
+  ptoTime: FortyTime.parse(0),
+  totalTime: FortyTime.parse(0),
+}
+
+const defaultWorkDays: WorkDay[] = [
   {
-    adjustMinutes: 0,
+    ...defaultDay,
     dayOfWeek: "Monday",
     id: 1,
-    inMinutes: 540,
-    outMinutes: 1020,
-    ptoMinutes: 0,
   },
   {
-    adjustMinutes: 0,
+    ...defaultDay,
     dayOfWeek: "Tuesday",
     id: 2,
-    inMinutes: 540,
-    outMinutes: 1020,
-    ptoMinutes: 0,
   },
   {
-    adjustMinutes: 0,
+    ...defaultDay,
     dayOfWeek: "Wednesday",
     id: 3,
-    inMinutes: 540,
-    outMinutes: 1020,
-    ptoMinutes: 0,
   },
   {
-    adjustMinutes: 0,
+    ...defaultDay,
     dayOfWeek: "Thursday",
     id: 4,
-    inMinutes: 540,
-    outMinutes: 1020,
-    ptoMinutes: 0,
   },
   {
-    adjustMinutes: 0,
+    ...defaultDay,
     dayOfWeek: "Friday",
     id: 5,
-    inMinutes: 540,
-    outMinutes: 1020,
-    ptoMinutes: 0,
   },
 ]
 
@@ -50,9 +44,14 @@ const mockFetcher: WeekEntryFetcher = new WeekEntryFetcher("invalid")
 mockFetcher.updateWorkDay = jest.fn()
 
 const defaultProps: WeekEntryProps = {
-  dates: "Feb 17-21, 2020",
   fetcher: mockFetcher,
-  workWeek: { workDays: defaultWorkDays },
+  lastWeekPath: "",
+  nextWeekPath: "",
+  thisWeekPath: "",
+  workWeek: {
+    dateSpan: "Feb 17-21, 2020",
+    workDays: defaultWorkDays,
+  },
 }
 
 describe("WeekEntry", () => {

--- a/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.spec.tsx
+++ b/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.spec.tsx
@@ -1,17 +1,15 @@
 import React from "react"
 import { mount } from "enzyme"
 import { WeekColumn, WeekColumnProps } from "./"
-
-const defaultWorkDay = {
-  adjustAmount: "0:00",
-  dayOfWeek: "Monday",
-  inTime: "8:00",
-  outTime: "17:00",
-  ptoAmount: "0:00",
-}
+import { defaultDay } from "../../WeekEntry.spec"
 
 const defaultProps: WeekColumnProps = {
-  workDay: defaultWorkDay,
+  handleWorkDayUpdate: jest.fn(),
+  workDay: {
+    ...defaultDay,
+    dayOfWeek: "Monday",
+    id: 1,
+  },
 }
 
 describe("WeekColumn", () => {

--- a/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
+++ b/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
@@ -1,138 +1,57 @@
-import React, { useState } from "react"
+import React from "react"
+import { WorkDay } from "../../WeekEntry"
 import { FortyTime } from "forty-time"
-
-export interface WorkDayData {
-  adjustAmount: string
-  dayOfWeek: string
-  id: number
-  inTime: string
-  outTime: string
-  ptoAmount: string
-}
 
 export interface WeekColumnProps {
   handleWorkDayUpdate: (id, key, value) => void
-  workDay: WorkDayData
-}
-
-const computeTotalTime = (
-  inTime: string,
-  outTime: string,
-  ptoAmount: string,
-  adjustAmount: string
-): string => {
-  const start = FortyTime.parse(inTime)
-  const end = FortyTime.parse(outTime)
-  const pto = FortyTime.parse(ptoAmount)
-  const adjust = FortyTime.parse(adjustAmount)
-  const total = end.minus(start).plus(pto).plus(adjust)
-  return total.toString()
+  workDay: WorkDay
 }
 
 export const WeekColumn: React.FC<WeekColumnProps> = (props) => {
   const { workDay } = props
-  const day = workDay.dayOfWeek
+  const shortDay = workDay.dayOfWeek.substring(0, 3)
+  const prefix = workDay.id
 
-  const [inTime, setInTime] = useState(workDay.inTime)
-  const [outTime, setOutTime] = useState(workDay.outTime)
-  const [ptoAmount, setPtoAmount] = useState(workDay.ptoAmount)
-  const [adjustAmount, setAdjustAmount] = useState(workDay.adjustAmount)
-  const initalTotal = computeTotalTime(
-    workDay.inTime,
-    workDay.outTime,
-    workDay.ptoAmount,
-    workDay.adjustAmount
-  )
-  const [totalTime, setTotalTime] = useState(initalTotal)
+  const handleChange = (e): void => {
+    const { name, value } = e.target
+    const [id, key] = name.split(".")
+    const minutes = FortyTime.parse(value).minutes
 
-  const handleInTimeChange = (e): void => {
-    const newInTime = e.target.value
-    setInTime(newInTime)
-    const newTotal = computeTotalTime(
-      newInTime,
-      outTime,
-      ptoAmount,
-      adjustAmount
-    )
-    setTotalTime(newTotal)
-    const inMinutes = FortyTime.parse(newInTime).minutes
-    props.handleWorkDayUpdate(workDay.id, "in_minutes", inMinutes)
-  }
-
-  const handleOutTimeChange = (e): void => {
-    const newOutTime = e.target.value
-    setOutTime(newOutTime)
-    const newTotal = computeTotalTime(
-      inTime,
-      newOutTime,
-      ptoAmount,
-      adjustAmount
-    )
-    setTotalTime(newTotal)
-    const outMinutes = FortyTime.parse(newOutTime).minutes
-    props.handleWorkDayUpdate(workDay.id, "out_minutes", outMinutes)
-  }
-
-  const handlePtoAmountChange = (e): void => {
-    const newPtoAmount = e.target.value
-    setPtoAmount(newPtoAmount)
-    const newTotal = computeTotalTime(
-      inTime,
-      outTime,
-      newPtoAmount,
-      adjustAmount
-    )
-    setTotalTime(newTotal)
-    const ptoMinutes = FortyTime.parse(newPtoAmount).minutes
-    props.handleWorkDayUpdate(workDay.id, "pto_minutes", ptoMinutes)
-  }
-
-  const handleAdjustAmountChange = (e): void => {
-    const newAdjustAmount = e.target.value
-    setAdjustAmount(newAdjustAmount)
-    const newTotal = computeTotalTime(
-      inTime,
-      outTime,
-      ptoAmount,
-      newAdjustAmount
-    )
-    setTotalTime(newTotal)
-    const adjustMinutes = FortyTime.parse(newAdjustAmount).minutes
-    props.handleWorkDayUpdate(workDay.id, "adjust_minutes", adjustMinutes)
+    props.handleWorkDayUpdate(id, key, minutes)
   }
 
   return (
     <section>
-      <p>{day.substring(0, 3)}</p>
+      <p>{shortDay}</p>
       <input
-        onChange={handleInTimeChange}
-        name={`${day.toLowerCase()}_in`}
+        defaultValue={workDay.inTime.toString()}
+        name={`${prefix}.inTime`}
+        onChange={handleChange}
         placeholder="in"
         type="text"
-        value={inTime}
       />
       <input
-        onChange={handleOutTimeChange}
-        name={`${day.toLowerCase()}_out`}
+        defaultValue={workDay.outTime.toString()}
+        name={`${prefix}.outTime`}
+        onChange={handleChange}
         placeholder="out"
         type="text"
-        value={outTime}
       />
       <input
-        onChange={handlePtoAmountChange}
-        name={`${day.toLowerCase()}_pto`}
+        defaultValue={workDay.ptoTime.toString()}
+        name={`${prefix}.ptoTime`}
+        onChange={handleChange}
         placeholder="pto"
         type="text"
-        value={ptoAmount}
       />
       <input
-        onChange={handleAdjustAmountChange}
-        name={`${day.toLowerCase()}_adjust`}
+        defaultValue={workDay.adjustTime.toString()}
+        name={`${prefix}.adjustTime`}
+        onChange={handleChange}
         placeholder="adjust"
         type="text"
-        value={adjustAmount}
       />
-      <p className={`${day.toLowerCase()}_total total`}>{totalTime}</p>
+      <p className={`total_${prefix} total`}>{workDay.totalTime.toString()}</p>
     </section>
   )
 }

--- a/app/javascript/packs/week_entry.tsx
+++ b/app/javascript/packs/week_entry.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { WeekEntry, WeekEntryProps } from "../apps/WeekEntry"
+import { calculateDayTotal, WeekEntry, WeekEntryProps } from "../apps/WeekEntry"
 import { WeekEntryFetcher } from "../apps/WeekEntry/WeekEntryFetcher"
+import { FortyTime } from "forty-time"
 
 document.addEventListener("DOMContentLoaded", () => {
   const root = document.getElementById("week_entry_root")
@@ -11,9 +12,39 @@ document.addEventListener("DOMContentLoaded", () => {
   const token = metaTag && metaTag.getAttribute("content")
   const fetcher = new WeekEntryFetcher(token)
 
+  const upgradedWorkDays = parsedProps.workWeek.workDays.map((workDay) => {
+    const {
+      adjustMinutes,
+      dayOfWeek,
+      id,
+      inMinutes,
+      outMinutes,
+      ptoMinutes,
+    } = workDay
+    const adjustTime = FortyTime.parse(adjustMinutes)
+    const inTime = FortyTime.parse(inMinutes)
+    const outTime = FortyTime.parse(outMinutes)
+    const ptoTime = FortyTime.parse(ptoMinutes)
+    const totalTime = calculateDayTotal(adjustTime, inTime, outTime, ptoTime)
+
+    return {
+      adjustTime,
+      dayOfWeek,
+      id,
+      inTime,
+      outTime,
+      ptoTime,
+      totalTime,
+    }
+  })
+
   const props: WeekEntryProps = {
     ...parsedProps,
     fetcher,
+    workWeek: {
+      ...parsedProps.workWeek,
+      workDays: upgradedWorkDays,
+    },
   }
 
   ReactDOM.render(<WeekEntry {...props} />, root)

--- a/spec/system/week_entry/full_entry_spec.rb
+++ b/spec/system/week_entry/full_entry_spec.rb
@@ -1,47 +1,42 @@
 require 'rails_helper'
 
-full_week_data = [
-  {
-    prefix: 'monday',
+full_week_data = {
+  'monday' => {
     in: '9:00',
     out: '17:00',
     pto: nil,
     adjust: nil,
     total: '8:00'
   },
-  {
-    prefix: 'tuesday',
+  'tuesday' => {
     in: nil,
     out: nil,
     pto: '8:00',
     adjust: nil,
     total: '8:00'
   },
-  {
-    prefix: 'wednesday',
+  'wednesday' => {
     in: '8:00',
     out: '17:00',
     pto: nil,
     adjust: nil,
     total: '9:00'
   },
-  {
-    prefix: 'thursday',
+  'thursday' => {
     in: '8:00',
     out: '17:00',
     pto: nil,
     adjust: '-1:00',
     total: '8:00'
   },
-  {
-    prefix: 'friday',
+  'friday' => {
     in: '11:00',
     out: '17:00',
     pto: '1:00',
     adjust: nil,
     total: '7:00'
   }
-]
+}
 
 describe 'Full week entry', js: true do
   it 'computes week total' do
@@ -50,14 +45,18 @@ describe 'Full week entry', js: true do
 
     visit '/today'
 
-    full_week_data.each do |day|
-      fill_in "#{day[:prefix]}_in", with: day[:in] if day[:in]
-      fill_in "#{day[:prefix]}_out", with: day[:out] if day[:out]
-      fill_in "#{day[:prefix]}_pto", with: day[:pto] if day[:pto]
-      fill_in "#{day[:prefix]}_adjust", with: day[:adjust] if day[:adjust]
+    WorkDay.all.each do |work_day|
+      day_of_week = work_day.date.strftime('%A').downcase
+      data = full_week_data[day_of_week]
+      prefix = work_day.id
 
-      day_total = page.find(".#{day[:prefix]}_total")
-      expect(day_total.text).to eq day[:total]
+      fill_in "#{prefix}.inTime", with: data[:in] if data[:in]
+      fill_in "#{prefix}.outTime", with: data[:out] if data[:out]
+      fill_in "#{prefix}.ptoTime", with: data[:pto] if data[:pto]
+      fill_in "#{prefix}.adjustTime", with: data[:adjust] if data[:adjust]
+
+      day_total = page.find(".total_#{prefix}")
+      expect(day_total.text).to eq data[:total]
     end
 
     # expect(page).to have_css('.grand_total', text: '40:00')


### PR DESCRIPTION
Rather than calculating inside the individual day components, I've pulled this part up into the parent component. This is better because it leads to a more natural way of computing the grand total and pace (to come). I also realized that I could eliminate the sorta-duplicate interfaces:

* WorkDay
* WorkDayData

I was getting in my own way here - better to define a single interface with the fields typed as FortyTime and then use the minutes or string representations when necessary.