### PR TITLE
Add grand total and pace

### DIFF
--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -59,26 +59,42 @@ body
       #week_entry_root
         nav
           display: flex
-          flex-direction: column
-          justify-content: center
-          text-align: right
+          justify-content: space-between
           padding-bottom: 30px
 
-          p
-            font-size: 20px
-          a
-            color: $off-black
-            background: $middle-gray
-            font-size: 16px
-            margin-left: 20px
-            padding: 4px 20px
-            text-decoration: none
-            transition: background-color $transition-config
-            transition: color $transition-config
+          .left
+            h1
+              color: $bright-green
+              font-family: $prompt
+              font-size: 80px
+              font-weight: 900
+              margin: 0
+              padding: 0
+            h1, p
+              display: inline
+          .right
+            display: flex
+            flex-direction: column
+            justify-content: center
+            text-align: right
 
-            &:hover, &:focus
-              background: $off-black
-              color: $bright-white
+            p
+              font-size: 20px
+              margin: 0 0 10px
+              padding: 0
+            a
+              color: $off-black
+              background: $middle-gray
+              font-size: 16px
+              margin-left: 20px
+              padding: 4px 20px
+              text-decoration: none
+              transition: background-color $transition-config
+              transition: color $transition-config
+
+              &:hover, &:focus
+                background: $off-black
+                color: $bright-white
 
         .table
           display: flex

--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -50,6 +50,8 @@ const defaultProps: WeekEntryProps = {
   thisWeekPath: "",
   workWeek: {
     dateSpan: "Feb 17-21, 2020",
+    grandTotal: FortyTime.parse(0),
+    pace: "even",
     workDays: defaultWorkDays,
   },
 }

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -26,6 +26,8 @@ export interface WorkDay {
 
 export interface WorkWeek {
   dateSpan: string
+  grandTotal: string
+  pace: string
   workDays: WorkDay[]
 }
 
@@ -62,6 +64,13 @@ const recalculate = (id, key, value, workWeek): WorkWeek => {
   )
   workDay.totalTime = updatedTotalTime
 
+  const grandTotalMinutes = updatedWorkWeek.workDays
+    .map((w) => w.totalTime.minutes)
+    .reduce((a, b) => a + b)
+  const grandTotal = FortyTime.parse(grandTotalMinutes)
+  updatedWorkWeek.grandTotal = grandTotal
+  updatedWorkWeek.pace = "even"
+
   return updatedWorkWeek
 }
 
@@ -91,10 +100,10 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
   return (
     <>
       <Header
-        dateSpan={workWeek.dateSpan}
         lastWeekPath={lastWeekPath}
         nextWeekPath={nextWeekPath}
         thisWeekPath={thisWeekPath}
+        workWeek={workWeek}
       />
       <div className="table">{weekColumns}</div>
     </>

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -3,16 +3,7 @@ import { WeekColumn } from "./components/WeekColumn"
 import { Header } from "./components/Header"
 import { WeekEntryFetcher } from "./WeekEntryFetcher"
 import { FortyTime } from "forty-time"
-
-export const calculateDayTotal = (
-  adjustTime,
-  inTime,
-  outTime,
-  ptoTime
-): FortyTime => {
-  const totalTime = outTime.minus(inTime).plus(ptoTime).plus(adjustTime)
-  return totalTime
-}
+import { recalculate } from "./helpers"
 
 export interface WorkDay {
   adjustTime: FortyTime
@@ -26,7 +17,7 @@ export interface WorkDay {
 
 export interface WorkWeek {
   dateSpan: string
-  grandTotal: string
+  grandTotal: FortyTime
   pace: string
   workDays: WorkDay[]
 }
@@ -44,34 +35,6 @@ const keyToAttributeMap = {
   inTime: "in_minutes",
   outTime: "out_minutes",
   ptoTime: "pto_minutes",
-}
-
-const recalculate = (id, key, value, workWeek): WorkWeek => {
-  const updatedWorkWeek = {
-    ...workWeek,
-  }
-
-  const workDay = updatedWorkWeek.workDays.find((w) => w.id.toString() === id)
-  workDay[key] = FortyTime.parse(value)
-
-  const { adjustTime, inTime, outTime, ptoTime } = workDay
-
-  const updatedTotalTime = calculateDayTotal(
-    adjustTime,
-    inTime,
-    outTime,
-    ptoTime
-  )
-  workDay.totalTime = updatedTotalTime
-
-  const grandTotalMinutes = updatedWorkWeek.workDays
-    .map((w) => w.totalTime.minutes)
-    .reduce((a, b) => a + b)
-  const grandTotal = FortyTime.parse(grandTotalMinutes)
-  updatedWorkWeek.grandTotal = grandTotal
-  updatedWorkWeek.pace = "even"
-
-  return updatedWorkWeek
 }
 
 export const WeekEntry: React.FC<WeekEntryProps> = (props) => {

--- a/app/javascript/apps/WeekEntry/components/Header/Header.tsx
+++ b/app/javascript/apps/WeekEntry/components/Header/Header.tsx
@@ -1,22 +1,30 @@
 import React from "react"
+import { WorkWeek } from "../../WeekEntry"
 
 export interface HeaderProps {
-  dateSpan: string
   lastWeekPath: string
   nextWeekPath: string
   thisWeekPath: string
+  workWeek: WorkWeek
 }
 
 export const Header: React.FC<HeaderProps> = (props) => {
-  const { dateSpan, lastWeekPath, nextWeekPath, thisWeekPath } = props
+  const { lastWeekPath, nextWeekPath, thisWeekPath, workWeek } = props
+  const { dateSpan, grandTotal, pace } = workWeek
 
   return (
     <nav>
-      <p>{dateSpan}</p>
-      <div>
-        <a href={lastWeekPath}>&lt;</a>
-        <a href={thisWeekPath}>this week</a>
-        <a href={nextWeekPath}>&gt;</a>
+      <div className="left">
+        <h1 className="grand_total">{grandTotal.toString()}</h1>
+        <p className="pace">{pace}</p>
+      </div>
+      <div className="right">
+        <p>{dateSpan}</p>
+        <div>
+          <a href={lastWeekPath}>&lt;</a>
+          <a href={thisWeekPath}>this week</a>
+          <a href={nextWeekPath}>&gt;</a>
+        </div>
       </div>
     </nav>
   )

--- a/app/javascript/apps/WeekEntry/helpers.ts
+++ b/app/javascript/apps/WeekEntry/helpers.ts
@@ -1,0 +1,66 @@
+import { FortyTime } from "forty-time"
+import { WorkDay, WorkWeek } from "./"
+
+export const convertToTimes = (workDays): WorkDay[] => {
+  return workDays.map((workDay) => {
+    return {
+      adjustTime: FortyTime.parse(workDay.adjustMinutes),
+      dayOfWeek: workDay.dayOfWeek,
+      id: workDay.id,
+      inTime: FortyTime.parse(workDay.inMinutes),
+      outTime: FortyTime.parse(workDay.outMinutes),
+      ptoTime: FortyTime.parse(workDay.ptoMinutes),
+      totalTime: FortyTime.parse(0),
+    }
+  })
+}
+
+export const calculateWorkDays = (workDays: WorkDay[]): WorkDay[] => {
+  return workDays.map((workDay) => {
+    const { adjustTime, inTime, outTime, ptoTime } = workDay
+    const totalTime = outTime.minus(inTime).plus(ptoTime).plus(adjustTime)
+
+    return {
+      ...workDay,
+      totalTime,
+    }
+  })
+}
+
+export const calculateGrandTotal = (workDays: WorkDay[]): FortyTime => {
+  const totalMinutes = workDays
+    .map((w) => w.totalTime.minutes)
+    .reduce((a, b) => a + b)
+  return FortyTime.parse(totalMinutes)
+}
+
+export const calculatePace = (
+  grandTotal: FortyTime,
+  target: FortyTime
+): string => {
+  const difference = grandTotal.minus(target)
+  if (difference.minutes === 0) return "even"
+
+  return difference.toString()
+}
+
+export const calculate = (workWeek: WorkWeek): WorkWeek => {
+  const workDays = calculateWorkDays(workWeek.workDays)
+  const grandTotal = calculateGrandTotal(workDays)
+  const target = FortyTime.parse("40:00")
+  const pace = calculatePace(grandTotal, target)
+
+  return {
+    ...workWeek,
+    grandTotal,
+    pace,
+    workDays,
+  }
+}
+
+export const recalculate = (id, key, value, workWeek): WorkWeek => {
+  const workDay = workWeek.workDays.find((w) => w.id.toString() === id)
+  workDay[key] = FortyTime.parse(value)
+  const updatedWorkWeek = calculate(workWeek)
+  return updatedWorkWeek
+}

--- a/app/javascript/packs/week_entry.tsx
+++ b/app/javascript/packs/week_entry.tsx
@@ -38,11 +38,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   })
 
+  const grandTotalMinutes = upgradedWorkDays
+    .map((w) => w.totalTime.minutes)
+    .reduce((a, b) => a + b)
+  const grandTotal = FortyTime.parse(grandTotalMinutes)
+  const pace = "even"
+
   const props: WeekEntryProps = {
     ...parsedProps,
     fetcher,
     workWeek: {
       ...parsedProps.workWeek,
+      grandTotal,
+      pace,
       workDays: upgradedWorkDays,
     },
   }

--- a/app/javascript/packs/week_entry.tsx
+++ b/app/javascript/packs/week_entry.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { calculateDayTotal, WeekEntry, WeekEntryProps } from "../apps/WeekEntry"
+import { WeekEntry, WeekEntryProps } from "../apps/WeekEntry"
+import { calculate, convertToTimes } from "../apps/WeekEntry/helpers"
 import { WeekEntryFetcher } from "../apps/WeekEntry/WeekEntryFetcher"
-import { FortyTime } from "forty-time"
 
 document.addEventListener("DOMContentLoaded", () => {
   const root = document.getElementById("week_entry_root")
@@ -11,48 +11,13 @@ document.addEventListener("DOMContentLoaded", () => {
   const metaTag = document.querySelector("meta[name=csrf-token]")
   const token = metaTag && metaTag.getAttribute("content")
   const fetcher = new WeekEntryFetcher(token)
-
-  const upgradedWorkDays = parsedProps.workWeek.workDays.map((workDay) => {
-    const {
-      adjustMinutes,
-      dayOfWeek,
-      id,
-      inMinutes,
-      outMinutes,
-      ptoMinutes,
-    } = workDay
-    const adjustTime = FortyTime.parse(adjustMinutes)
-    const inTime = FortyTime.parse(inMinutes)
-    const outTime = FortyTime.parse(outMinutes)
-    const ptoTime = FortyTime.parse(ptoMinutes)
-    const totalTime = calculateDayTotal(adjustTime, inTime, outTime, ptoTime)
-
-    return {
-      adjustTime,
-      dayOfWeek,
-      id,
-      inTime,
-      outTime,
-      ptoTime,
-      totalTime,
-    }
-  })
-
-  const grandTotalMinutes = upgradedWorkDays
-    .map((w) => w.totalTime.minutes)
-    .reduce((a, b) => a + b)
-  const grandTotal = FortyTime.parse(grandTotalMinutes)
-  const pace = "even"
+  parsedProps.workWeek.workDays = convertToTimes(parsedProps.workWeek.workDays)
+  const workWeek = calculate(parsedProps.workWeek)
 
   const props: WeekEntryProps = {
     ...parsedProps,
     fetcher,
-    workWeek: {
-      ...parsedProps.workWeek,
-      grandTotal,
-      pace,
-      workDays: upgradedWorkDays,
-    },
+    workWeek,
   }
 
   ReactDOM.render(<WeekEntry {...props} />, root)

--- a/spec/system/week_entry/full_entry_spec.rb
+++ b/spec/system/week_entry/full_entry_spec.rb
@@ -59,7 +59,7 @@ describe 'Full week entry', js: true do
       expect(day_total.text).to eq data[:total]
     end
 
-    # expect(page).to have_css('.grand_total', text: '40:00')
-    # expect(page).to have_css('.pace', text: 'even')
+    expect(page).to have_css('.grand_total', text: '40:00')
+    expect(page).to have_css('.pace', text: 'even')
   end
 end


### PR DESCRIPTION
This PR rounds out the basic week entry screen to match the comps I had done a while back by adding grand total and pace:

<img width="1255" alt="Screen Shot 2020-04-20 at 8 39 51 PM" src="https://user-images.githubusercontent.com/79799/79815786-2ed74d00-8347-11ea-9b72-9d926eb4c723.png">

In order to do this I've added these fields to the WorkWeek interface and the moves all my calculation into a helpers file. These things are computed during boot in the pack file and then recomputed as changes are bubbled up the stack.