### PR TITLE
Improve week entry UX

### DIFF
--- a/app/javascript/apps/WeekEntry/components/TimeInput/TimeInput.tsx
+++ b/app/javascript/apps/WeekEntry/components/TimeInput/TimeInput.tsx
@@ -1,0 +1,32 @@
+import React from "react"
+import { FortyTime } from "forty-time"
+
+export interface TimeInputProps {
+  handleWorkDayUpdate: (id, key, value) => void
+  id: number
+  placeholder: string
+  property: string
+  time: FortyTime
+}
+
+export const TimeInput: React.FC<TimeInputProps> = (props) => {
+  const { handleWorkDayUpdate, id, placeholder, property, time } = props
+
+  const name = [id, property].join(".")
+  const value = time.toString()
+
+  const handleChange = (e): void => {
+    const newTime = FortyTime.parse(e.target.value)
+    handleWorkDayUpdate(id, property, newTime.minutes)
+  }
+
+  return (
+    <input
+      defaultValue={value}
+      name={name}
+      onChange={handleChange}
+      placeholder={placeholder}
+      type="text"
+    />
+  )
+}

--- a/app/javascript/apps/WeekEntry/components/TimeInput/TimeInput.tsx
+++ b/app/javascript/apps/WeekEntry/components/TimeInput/TimeInput.tsx
@@ -1,5 +1,12 @@
-import React from "react"
+import React, { useState } from "react"
 import { FortyTime } from "forty-time"
+
+const pattern = /^[-0-9:]*$/
+
+const EnterKeyCode = 13
+const EscKeyCode = 27
+
+const CommitKeyCodes = [EnterKeyCode, EscKeyCode]
 
 export interface TimeInputProps {
   handleWorkDayUpdate: (id, key, value) => void
@@ -12,21 +19,40 @@ export interface TimeInputProps {
 export const TimeInput: React.FC<TimeInputProps> = (props) => {
   const { handleWorkDayUpdate, id, placeholder, property, time } = props
 
+  const [value, setValue] = useState(time.toString())
+
   const name = [id, property].join(".")
-  const value = time.toString()
+
+  const handleBlur = (e): void => {
+    const newTime = FortyTime.parse(e.target.value)
+    setValue(newTime.toString())
+    handleWorkDayUpdate(id, property, newTime.minutes)
+  }
 
   const handleChange = (e): void => {
-    const newTime = FortyTime.parse(e.target.value)
-    handleWorkDayUpdate(id, property, newTime.minutes)
+    const newValue = e.target.value
+
+    if (newValue.match(pattern) && newValue.length < 7) {
+      setValue(newValue)
+    }
+  }
+
+  const handleKeyUp = (e): void => {
+    if (CommitKeyCodes.includes(e.keyCode)) {
+      e.target.blur()
+      e.target.select()
+    }
   }
 
   return (
     <input
-      defaultValue={value}
       name={name}
+      onBlur={handleBlur}
       onChange={handleChange}
+      onKeyUp={handleKeyUp}
       placeholder={placeholder}
       type="text"
+      value={value}
     />
   )
 }

--- a/app/javascript/apps/WeekEntry/components/TimeInput/index.tsx
+++ b/app/javascript/apps/WeekEntry/components/TimeInput/index.tsx
@@ -1,0 +1,1 @@
+export * from "./TimeInput"

--- a/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
+++ b/app/javascript/apps/WeekEntry/components/WeekColumn/WeekColumn.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { WorkDay } from "../../WeekEntry"
-import { FortyTime } from "forty-time"
+import { TimeInput } from "../TimeInput"
 
 export interface WeekColumnProps {
   handleWorkDayUpdate: (id, key, value) => void
@@ -10,48 +10,42 @@ export interface WeekColumnProps {
 export const WeekColumn: React.FC<WeekColumnProps> = (props) => {
   const { workDay } = props
   const shortDay = workDay.dayOfWeek.substring(0, 3)
-  const prefix = workDay.id
 
-  const handleChange = (e): void => {
-    const { name, value } = e.target
-    const [id, key] = name.split(".")
-    const minutes = FortyTime.parse(value).minutes
-
-    props.handleWorkDayUpdate(id, key, minutes)
+  const defaultInputProps = {
+    handleWorkDayUpdate: props.handleWorkDayUpdate,
+    id: workDay.id,
   }
 
   return (
     <section>
       <p>{shortDay}</p>
-      <input
-        defaultValue={workDay.inTime.toString()}
-        name={`${prefix}.inTime`}
-        onChange={handleChange}
+      <TimeInput
+        {...defaultInputProps}
         placeholder="in"
-        type="text"
+        property="inTime"
+        time={workDay.inTime}
       />
-      <input
-        defaultValue={workDay.outTime.toString()}
-        name={`${prefix}.outTime`}
-        onChange={handleChange}
+      <TimeInput
+        {...defaultInputProps}
         placeholder="out"
-        type="text"
+        property="outTime"
+        time={workDay.outTime}
       />
-      <input
-        defaultValue={workDay.ptoTime.toString()}
-        name={`${prefix}.ptoTime`}
-        onChange={handleChange}
+      <TimeInput
+        {...defaultInputProps}
         placeholder="pto"
-        type="text"
+        property="ptoTime"
+        time={workDay.ptoTime}
       />
-      <input
-        defaultValue={workDay.adjustTime.toString()}
-        name={`${prefix}.adjustTime`}
-        onChange={handleChange}
+      <TimeInput
+        {...defaultInputProps}
         placeholder="adjust"
-        type="text"
+        property="adjustTime"
+        time={workDay.adjustTime}
       />
-      <p className={`total_${prefix} total`}>{workDay.totalTime.toString()}</p>
+      <p className={`total_${workDay.id} total`}>
+        {workDay.totalTime.toString()}
+      </p>
     </section>
   )
 }

--- a/app/javascript/apps/WeekEntry/helpers.ts
+++ b/app/javascript/apps/WeekEntry/helpers.ts
@@ -59,7 +59,7 @@ export const calculate = (workWeek: WorkWeek): WorkWeek => {
 }
 
 export const recalculate = (id, key, value, workWeek): WorkWeek => {
-  const workDay = workWeek.workDays.find((w) => w.id.toString() === id)
+  const workDay = workWeek.workDays.find((w) => w.id === id)
   workDay[key] = FortyTime.parse(value)
   const updatedWorkWeek = calculate(workWeek)
   return updatedWorkWeek

--- a/spec/system/week_entry/full_entry_spec.rb
+++ b/spec/system/week_entry/full_entry_spec.rb
@@ -48,14 +48,14 @@ describe 'Full week entry', js: true do
     WorkDay.all.each do |work_day|
       day_of_week = work_day.date.strftime('%A').downcase
       data = full_week_data[day_of_week]
-      prefix = work_day.id
+      id = work_day.id
 
-      fill_in "#{prefix}.inTime", with: data[:in] if data[:in]
-      fill_in "#{prefix}.outTime", with: data[:out] if data[:out]
-      fill_in "#{prefix}.ptoTime", with: data[:pto] if data[:pto]
-      fill_in "#{prefix}.adjustTime", with: data[:adjust] if data[:adjust]
+      fill_in "#{id}.inTime", with: "#{data[:in]}\n" if data[:in]
+      fill_in "#{id}.outTime", with: "#{data[:out]}\n" if data[:out]
+      fill_in "#{id}.ptoTime", with: "#{data[:pto]}\n" if data[:pto]
+      fill_in "#{id}.adjustTime", with: "#{data[:adjust]}\n" if data[:adjust]
 
-      day_total = page.find(".total_#{prefix}")
+      day_total = page.find(".total_#{id}")
       expect(day_total.text).to eq data[:total]
     end
 


### PR DESCRIPTION
There are a number of subtle UX improvements here, mostly around how/when things update. I started by extracting a component for each time input so that I could more easily tailor how they behaved.

What I wanted to achieve:

* only update the server on blur, not on every change
* ensure the newly persisted and parsed time was reflected in the UI
* block obviously wrong inputs
* support pressing the enter key to accept the changes you've made
* ditto for the esc key

And I got it all to work! The biggest thing was to separate the different event handlers more clearly, something that would have been quite tedious in the parent component. I tinkered with this quite a bit including the regex used to block obviously wrong inputs. It's possible I'll be revisiting this, but the current pattern seems to strike a good balance of being simple and catching lots of mistakes.