### PR TITLE
Improve pace calculation

### DIFF
--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -19,6 +19,7 @@ export interface WorkWeek {
   dateSpan: string
   grandTotal: FortyTime
   pace: string
+  weekToDateIds: number[]
   workDays: WorkDay[]
 }
 

--- a/app/javascript/apps/WeekEntry/helpers.ts
+++ b/app/javascript/apps/WeekEntry/helpers.ts
@@ -29,28 +29,49 @@ export const calculateWorkDays = (workDays: WorkDay[]): WorkDay[] => {
   })
 }
 
-export const calculateGrandTotal = (workDays: WorkDay[]): FortyTime => {
+export const calculateTotal = (workDays: WorkDay[]): FortyTime => {
   const totalMinutes = workDays
     .map((w) => w.totalTime.minutes)
-    .reduce((a, b) => a + b)
+    .reduce((a, b) => a + b, 0)
   return FortyTime.parse(totalMinutes)
 }
 
-export const calculatePace = (
-  grandTotal: FortyTime,
-  target: FortyTime
-): string => {
-  const difference = grandTotal.minus(target)
+export const calculatePace = (total: FortyTime, target: FortyTime): string => {
+  const difference = total.minus(target)
   if (difference.minutes === 0) return "even"
 
   return difference.toString()
 }
 
+interface WeekToDate {
+  target: FortyTime
+  total: FortyTime
+}
+
+const calculateWeekToDate = (
+  workDays: WorkDay[],
+  weekToDateIds: number[]
+): WeekToDate => {
+  const targetMinutes = weekToDateIds.length * 8 * 60
+  const target = FortyTime.parse(targetMinutes)
+
+  const weekToDateDays = workDays.filter((day) => {
+    return weekToDateIds.includes(day.id)
+  })
+
+  const total = calculateTotal(weekToDateDays)
+
+  return {
+    target,
+    total,
+  }
+}
+
 export const calculate = (workWeek: WorkWeek): WorkWeek => {
   const workDays = calculateWorkDays(workWeek.workDays)
-  const grandTotal = calculateGrandTotal(workDays)
-  const target = FortyTime.parse("40:00")
-  const pace = calculatePace(grandTotal, target)
+  const grandTotal = calculateTotal(workDays)
+  const weekToDate = calculateWeekToDate(workDays, workWeek.weekToDateIds)
+  const pace = calculatePace(weekToDate.total, weekToDate.target)
 
   return {
     ...workWeek,

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -27,6 +27,7 @@ class WorkWeek
   def as_json(_)
     {
       dateSpan: date_span,
+      weekToDateIds: week_to_date_ids,
       workDays: @work_days
     }
   end
@@ -36,6 +37,11 @@ class WorkWeek
   end
 
   private
+
+  def week_to_date_ids
+    days = @work_days.select { |day| day.date <= Time.zone.today }
+    days.map(&:id)
+  end
 
   def date_span
     monday = dates.first


### PR DESCRIPTION
Prior to this commit pace was always calculated with your grand total and a target of 40 hours. What this PR does is improve the calculation on both counts:

* only sum the days that you've worked, not future days
* calculate a target based on how many days into the week we are 

So this way your pace is a better reflection of how you're doing on the week.