### PR TITLE
Improve colors of pry console prompt

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,19 @@
+Pry.configure do |config|
+  color_map = {
+    'development' => 'green',
+    'fallback' => 'white',
+    'production' => 'red',
+    'staging' => 'yellow',
+    'test' => 'purple'
+  }
+
+  rails_env_name = defined?(Rails) && Rails.env
+  env_console_name = ENV['CONSOLE_COLOR_ENV']
+  env_name = env_console_name || rails_env_name
+  project_name = File.basename(Dir.pwd)
+  prompt_name = [project_name, env_name].compact.join(':')
+  helper_type = color_map.fetch(env_name, color_map['fallback'])
+  color_helper = Pry::Helpers::Text.method(helper_type)
+
+  config.prompt_name = color_helper.call(prompt_name)
+end


### PR DESCRIPTION
I went to go use [console_color](https://github.com/joeyAghion/console_color) only to discover that it's not compatible with [pry](https://github.com/pry/pry)! After some tinkering and playing around I landed on the following config in order to have my prompt colored nicely:

<img width="796" alt="Screen Shot 2020-05-26 at 9 43 54 PM" src="https://user-images.githubusercontent.com/79799/82972191-0a9c0b00-9f9a-11ea-9df4-dead8b29d40d.png">

So the way this works is the first part is based on the name of the current working directory and then the second part is a little tricky. The environment name comes first from an ENV var and then falls back to the Rails env and finally falls back to a white default. Not perfect, but I think it's pretty ok. Oh and I also check to see if we're even in a Rails project - is that overkill here in forty-web? Yeah, probably, but now I can copy/paste this into other projects and it should Just Work ™️ .