### PR TITLE
Further console prompt improvements

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -7,11 +7,16 @@ Pry.configure do |config|
     'test' => 'purple'
   }
 
-  rails_env_name = defined?(Rails) && Rails.env
   env_console_name = ENV['CONSOLE_COLOR_ENV']
+  rails_env_name = defined?(Rails) && Rails.env
   env_name = env_console_name || rails_env_name
-  project_name = File.basename(Dir.pwd)
+
+  app_name = defined?(Rails) && Rails.application.class.module_parent_name
+  folder_name = File.basename(Dir.pwd)
+  project_name = (app_name || folder_name).downcase
+
   prompt_name = [project_name, env_name].compact.join(':')
+
   helper_type = color_map.fetch(env_name, color_map['fallback'])
   color_helper = Pry::Helpers::Text.method(helper_type)
 


### PR DESCRIPTION
Turns out the folder name on Heroku was just coming out as "app" so this fixes it so that we look to Rails to tell us what the app name is if it exists. The fallback is still the folder name, but this is better overall.