### PR TITLE
Move config reference to later in boot sequence

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,5 @@
 Rails.application.configure do
   config.action_controller.perform_caching = true
-  config.action_mailer.default_url_options = { host: Forty.config.email_host }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_caching = false
   config.active_job.queue_adapter = :sidekiq

--- a/config/initializers/email.rb
+++ b/config/initializers/email.rb
@@ -1,3 +1,5 @@
+ActionMailer::Base.default_url_options = { host: Forty.config.email_host } if Rails.env.production?
+
 ActionMailer::Base.smtp_settings = {
   address: Forty.config.smtp_address,
   authentication: Forty.config.smtp_authentication,


### PR DESCRIPTION
This PR fixes a broken Heroku deploy that resulted from not understanding the Rails boot sequence. What happened was that the Heroku deploy failed because `rake assets:precompile` failed, but that was really only because the environment couldn't boot.

And that happened because I tried to reference `Forty.config` in an environment file - oops!

So all this PR does is move that config over the the email initializer.