### PR TITLE
Refactor feature flagging

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
 CREDS_GROUP=test
-UPGRADE=true
+FEATURE_UPGRADE=enabled

--- a/app/controllers/upgrade_controller.rb
+++ b/app/controllers/upgrade_controller.rb
@@ -20,6 +20,6 @@ class UpgradeController < AuthenticatedController
   private
 
   def ensure_upgrade_feature
-    redirect_to root_path unless Feature.enabled?(Feature::UPGRADE)
+    redirect_to root_path unless Feature.enabled?(:upgrade)
   end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,9 +1,16 @@
 class Feature
-  FLAGS = [
-    UPGRADE = 'UPGRADE'.freeze
-  ].freeze
+  FLAG_NAME_MAP = {
+    sanity: 'FEATURE_SANITY',
+    upgrade: 'FEATURE_UPGRADE'
+  }.freeze
+
+  class UnknownFeatureFlag < StandardError; end
 
   def self.enabled?(feature_name)
-    Forty.config.features[feature_name]
+    raise UnknownFeatureFlag unless FLAG_NAME_MAP.keys.include?(feature_name)
+
+    flag_name = FLAG_NAME_MAP[feature_name]
+    flag_value = ENV[flag_name] || 'disabled'
+    flag_value == 'enabled'
   end
 end

--- a/app/views/account/show.html.haml
+++ b/app/views/account/show.html.haml
@@ -2,7 +2,7 @@
   = link_to 'sign out', sign_out_path, class: 'button'
   %p Signed in as #{current_user.email}
 
-  - if Feature.enabled?(Feature::UPGRADE)
+  - if Feature.enabled?(:upgrade)
     - if current_user.comped?
       %p You are comped! :heart_eyes:
     - elsif current_user.active?

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,8 @@ require 'rails/all'
 
 Bundler.require(*Rails.groups)
 
+Warning[:deprecated] = false
+
 module Forty
   class Application < Rails::Application
     config.active_record.schema_format = :sql

--- a/config/initializers/01_forty_config.rb
+++ b/config/initializers/01_forty_config.rb
@@ -24,8 +24,6 @@ module Forty
       admin_email: group[:admin_email],
       email_host: group[:email_host],
 
-      features: features,
-
       sidekiq_admin_username: group.dig(:sidekiq_admin, :username),
       sidekiq_admin_password: group.dig(:sidekiq_admin, :password),
 
@@ -40,12 +38,6 @@ module Forty
       stripe_private_key: group.dig(:stripe, :private_key),
       stripe_public_key: group.dig(:stripe, :public_key)
     }
-  end
-
-  private_class_method def self.features
-    Feature::FLAGS.index_with do |feature|
-      ENV.fetch(feature, 'false') == 'true'
-    end
   end
 end
 

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe 'Feature' do
+  describe '.enabled?' do
+    context 'with an unknown flag' do
+      it 'raises an error' do
+        expect do
+          Feature.enabled?(:invalid)
+        end.to raise_error(Feature::UnknownFeatureFlag)
+      end
+    end
+
+    context 'with a known flag' do
+      before do
+        expect(ENV).to receive(:[]).with('FEATURE_SANITY').and_return(flag_value)
+      end
+
+      context 'with a flag not found in ENV' do
+        let(:flag_value) { nil }
+
+        it 'returns false' do
+          enabled = Feature.enabled?(:sanity)
+          expect(enabled).to eq false
+        end
+      end
+
+      context 'with a flag set as disabled in ENV' do
+        let(:flag_value) { 'disabled' }
+
+        it 'returns false' do
+          enabled = Feature.enabled?(:sanity)
+          expect(enabled).to eq false
+        end
+      end
+
+      context 'with a flag set as enabled in ENV' do
+        let(:flag_value) { 'enabled' }
+
+        it 'returns true' do
+          enabled = Feature.enabled?(:sanity)
+          expect(enabled).to eq true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I took another pass at my feature flagging abilities on this app and I think I like what I came up with a lot better! For starters, I'm no longer hanging features off of config - that was a dumb idea that caused Rails auto-loading code to yell at me.

Instead now I just have a Feature class that maps symbols to ENV keys.

I also took a second to think about how I'll review these values on Heroku and decided to "namespace" them under `FEATURE` so that I can do this:

```
$ heroku config -r production | grep FEATURE
FEATURE_SANITY:             enabled
FEATURE_UPGRADE:            disabled
```

And that'll be really handy when I want to see what's what.

I also added a spec!