### PR TITLE
feat: Free user sees disabled work week

### DIFF
--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -216,7 +216,6 @@ body
         nav
           display: flex
           justify-content: space-between
-          padding-bottom: 30px
 
           .left
             h1
@@ -241,10 +240,17 @@ body
             a
               margin-left: 20px
 
+        .nudge
+          background-color: $bright-yellow
+          margin: 0
+          padding: 20px
+          text-align: center
+
         .table
           display: flex
           flex-direction: row
           justify-content: space-between
+          padding-top: 30px
 
           section
             display: flex

--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -227,6 +227,29 @@ body
               padding: 0
             h1, p
               display: inline
+            &.null
+              display: flex
+              align-items: flex-end
+              margin-top: 30px
+              margin-bottom: 30px
+
+              h1
+                background-color: $bright-green
+                height: 60px
+                width: 200px
+                margin: 0 10px 0 0
+                padding: 0
+
+              p
+                background-color: $off-black
+                height: 16px
+                width: 40px
+                margin: 0
+                padding: 0
+
+              h1, p
+                display: block
+
           .right
             display: flex
             flex-direction: column
@@ -293,3 +316,34 @@ body
                   border-bottom: 10px solid $bright-green
 
     footer
+
+.nullWorkWeek
+  .wrapper
+    display: flex
+    justify-content: flex-end
+    margin: 20px 0 0
+    padding: 0
+    width: 100%
+
+    .inner
+      height: 30px
+
+    &.inTime, &.outTime, &.ptoTime, &.adjustTime
+      border-bottom: 10px solid $light-gray
+
+      .inner
+        background-color: $middle-gray
+        margin-bottom: 10px
+
+    &.inTime .inner
+      width: 30px
+
+    &.outTime .inner, &.ptoTime .inner
+      width: 50px
+
+    &.adjustTime .inner
+      width: 80px
+
+    &.total .inner
+      background-color: $off-black
+      width: 60px

--- a/app/controllers/work_weeks_controller.rb
+++ b/app/controllers/work_weeks_controller.rb
@@ -9,7 +9,8 @@ class WorkWeeksController < AuthenticatedController
       lastWeekPath: last_week_path,
       nextWeekPath: next_week_path,
       thisWeekPath: this_week_path,
-      workWeek: work_week
+      workWeek: work_week,
+      user: current_user
     }
   end
 

--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -51,6 +51,7 @@ const defaultProps: WeekEntryProps = {
   workWeek: {
     dateSpan: "Feb 17-21, 2020",
     grandTotal: FortyTime.parse(0),
+    isDisabled: false,
     pace: "even",
     weekToDateIds: [],
     workDays: defaultWorkDays,

--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -52,6 +52,7 @@ const defaultProps: WeekEntryProps = {
     dateSpan: "Feb 17-21, 2020",
     grandTotal: FortyTime.parse(0),
     pace: "even",
+    weekToDateIds: [],
     workDays: defaultWorkDays,
   },
 }

--- a/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.spec.tsx
@@ -55,6 +55,9 @@ const defaultProps: WeekEntryProps = {
     weekToDateIds: [],
     workDays: defaultWorkDays,
   },
+  user: {
+    isFree: false,
+  },
 }
 
 describe("WeekEntry", () => {

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import { WeekColumn } from "./components/WeekColumn"
-import { Header } from "./components/Header"
+import { NullWeekColumns } from "./components/NullWeekColumn"
+import { Header as DefaultHeader, NullHeader } from "./components/Header"
 import { WeekEntryFetcher } from "./WeekEntryFetcher"
 import { FortyTime } from "forty-time"
 import { recalculate } from "./helpers"
@@ -27,6 +28,7 @@ export interface WorkDay {
 export interface WorkWeek {
   dateSpan: string
   grandTotal: FortyTime
+  isDisabled: boolean
   pace: string
   weekToDateIds: number[]
   workDays: WorkDay[]
@@ -75,6 +77,11 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
     )
   })
 
+  const showNull = props.workWeek.isDisabled
+
+  const columns = showNull ? NullWeekColumns : weekColumns
+  const Header = showNull ? NullHeader : DefaultHeader
+
   const showNudge = user.isFree
 
   return (
@@ -86,7 +93,7 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
         workWeek={workWeek}
       />
       {showNudge && <Nudge />}
-      <div className="table">{weekColumns}</div>
+      <div className="table">{columns}</div>
     </>
   )
 }

--- a/app/javascript/apps/WeekEntry/WeekEntry.tsx
+++ b/app/javascript/apps/WeekEntry/WeekEntry.tsx
@@ -5,6 +5,15 @@ import { WeekEntryFetcher } from "./WeekEntryFetcher"
 import { FortyTime } from "forty-time"
 import { recalculate } from "./helpers"
 
+const Nudge = () => {
+  return (
+    <p className="nudge">
+      Free accounts only have access to the current and previous week -{" "}
+      <a href="/upgrade">upgrade your account</a>!
+    </p>
+  )
+}
+
 export interface WorkDay {
   adjustTime: FortyTime
   dayOfWeek: string
@@ -23,12 +32,17 @@ export interface WorkWeek {
   workDays: WorkDay[]
 }
 
+export interface User {
+  isFree: boolean
+}
+
 export interface WeekEntryProps {
   fetcher: WeekEntryFetcher
   lastWeekPath: string
   nextWeekPath: string
   thisWeekPath: string
   workWeek: WorkWeek
+  user: User
 }
 
 const keyToAttributeMap = {
@@ -39,7 +53,7 @@ const keyToAttributeMap = {
 }
 
 export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
-  const { lastWeekPath, nextWeekPath, thisWeekPath } = props
+  const { lastWeekPath, nextWeekPath, thisWeekPath, user } = props
   const [workWeek, setWorkWeek] = useState(props.workWeek)
 
   const handleWorkDayUpdate = (id, key, value): void => {
@@ -61,6 +75,8 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
     )
   })
 
+  const showNudge = user.isFree
+
   return (
     <>
       <Header
@@ -69,6 +85,7 @@ export const WeekEntry: React.FC<WeekEntryProps> = (props) => {
         thisWeekPath={thisWeekPath}
         workWeek={workWeek}
       />
+      {showNudge && <Nudge />}
       <div className="table">{weekColumns}</div>
     </>
   )

--- a/app/javascript/apps/WeekEntry/components/Header/Header.tsx
+++ b/app/javascript/apps/WeekEntry/components/Header/Header.tsx
@@ -8,6 +8,34 @@ export interface HeaderProps {
   workWeek: WorkWeek
 }
 
+export const NullHeader: React.FC<HeaderProps> = (props) => {
+  const { lastWeekPath, nextWeekPath, thisWeekPath, workWeek } = props
+  const { dateSpan } = workWeek
+
+  return (
+    <nav>
+      <div className="left null">
+        <h1 className="grand_total">&nbsp;</h1>
+        <p className="pace">&nbsp;</p>
+      </div>
+      <div className="right">
+        <p>{dateSpan}</p>
+        <div>
+          <a className="button" href={lastWeekPath}>
+            &lt;
+          </a>
+          <a className="button" href={thisWeekPath}>
+            this week
+          </a>
+          <a className="button" href={nextWeekPath}>
+            &gt;
+          </a>
+        </div>
+      </div>
+    </nav>
+  )
+}
+
 export const Header: React.FC<HeaderProps> = (props) => {
   const { lastWeekPath, nextWeekPath, thisWeekPath, workWeek } = props
   const { dateSpan, grandTotal, pace } = workWeek

--- a/app/javascript/apps/WeekEntry/components/NullWeekColumn/NullWeekColumn.tsx
+++ b/app/javascript/apps/WeekEntry/components/NullWeekColumn/NullWeekColumn.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+
+interface NullWeekColumnProps {
+  dayOfWeek: string
+}
+
+export const NullWeekColumn: React.FC<NullWeekColumnProps> = (props) => {
+  return (
+    <section className="nullWorkWeek">
+      <p>{props.dayOfWeek}</p>
+      <div className="wrapper inTime">
+        <div className="inner" />
+      </div>
+      <div className="wrapper outTime">
+        <div className="inner" />
+      </div>
+      <div className="wrapper ptoTime">
+        <div className="inner" />
+      </div>
+      <div className="wrapper adjustTime">
+        <div className="inner" />
+      </div>
+      <div className="wrapper total">
+        <div className="inner" />
+      </div>
+    </section>
+  )
+}
+
+const nullWorkDays = [
+  { dayOfWeek: "Mon", id: 1 },
+  { dayOfWeek: "Tue", id: 2 },
+  { dayOfWeek: "Wed", id: 3 },
+  { dayOfWeek: "Thu", id: 4 },
+  { dayOfWeek: "Fri", id: 5 },
+]
+
+export const NullWeekColumns = nullWorkDays.map((nullWorkDay) => {
+  const { dayOfWeek, id } = nullWorkDay
+  return <NullWeekColumn key={id} dayOfWeek={dayOfWeek} />
+})

--- a/app/javascript/apps/WeekEntry/components/NullWeekColumn/index.ts
+++ b/app/javascript/apps/WeekEntry/components/NullWeekColumn/index.ts
@@ -1,0 +1,1 @@
+export * from "./NullWeekColumn"

--- a/app/models/base_work_week.rb
+++ b/app/models/base_work_week.rb
@@ -5,7 +5,9 @@ class BaseWorkWeek
   attr_reader :number, :user, :year
 
   def self.find_or_create_by(user:, year:, number:)
-    work_week = WorkWeek.new(user, year, number)
+    klass = user.can_view?(year, number) ? WorkWeek : NullWorkWeek
+
+    work_week = klass.new(user, year, number)
     work_week.find_or_create
     work_week
   rescue InvalidDates
@@ -26,6 +28,7 @@ class BaseWorkWeek
   def as_json(_)
     {
       dateSpan: date_span,
+      isDisabled: disabled?,
       weekToDateIds: week_to_date_ids,
       workDays: work_days
     }
@@ -37,14 +40,18 @@ class BaseWorkWeek
 
   private
 
-  def week_to_date_ids
-    raise 'Implement in subclass'
-  end
-
   def date_span
     monday = dates.first
     friday = dates.last
     (monday..friday).to_s(:date_span)
+  end
+
+  def disabled?
+    raise 'Implement in subclass'
+  end
+
+  def week_to_date_ids
+    raise 'Implement in subclass'
   end
 
   def dates

--- a/app/models/base_work_week.rb
+++ b/app/models/base_work_week.rb
@@ -1,0 +1,61 @@
+class BaseWorkWeek
+  class InvalidDates < StandardError; end
+
+  attr_accessor :work_days
+  attr_reader :number, :user, :year
+
+  def self.find_or_create_by(user:, year:, number:)
+    work_week = WorkWeek.new(user, year, number)
+    work_week.find_or_create
+    work_week
+  rescue InvalidDates
+    # year and/or number failed to parse as valid date
+  end
+
+  def initialize(user, year, number)
+    @user = user
+    @year = year.to_i
+    @number = number.to_i
+    @work_days = []
+  end
+
+  def find_or_create
+    raise 'Implement in subclass'
+  end
+
+  def as_json(_)
+    {
+      dateSpan: date_span,
+      weekToDateIds: week_to_date_ids,
+      workDays: work_days
+    }
+  end
+
+  def target_date
+    dates.first
+  end
+
+  private
+
+  def week_to_date_ids
+    raise 'Implement in subclass'
+  end
+
+  def date_span
+    monday = dates.first
+    friday = dates.last
+    (monday..friday).to_s(:date_span)
+  end
+
+  def dates
+    @dates ||= compute_dates
+  end
+
+  def compute_dates
+    raise InvalidDates unless year.positive? && number.positive?
+
+    (1..5).map { |day| Date.commercial(year, number, day) }
+  rescue StandardError
+    raise InvalidDates
+  end
+end

--- a/app/models/null_work_week.rb
+++ b/app/models/null_work_week.rb
@@ -1,0 +1,15 @@
+class NullWorkWeek < BaseWorkWeek
+  def find_or_create
+    # noop
+  end
+
+  private
+
+  def disabled?
+    true
+  end
+
+  def week_to_date_ids
+    []
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,23 @@ class User < ApplicationRecord
     !active? && !comped?
   end
 
+  def can_view?(year, number)
+    return true unless free?
+
+    today = Time.zone.today
+    this_week_year = today.cwyear.to_s
+    this_week_number = today.strftime('%V')
+
+    last_week = today - 1.week
+    last_week_year = last_week.cwyear.to_s
+    last_week_number = last_week.strftime('%V')
+
+    requesting_this_week = year == this_week_year && number == this_week_number
+    requesting_last_week = year == last_week_year && number == last_week_number
+
+    requesting_this_week || requesting_last_week
+  end
+
   def as_json(_)
     {
       isFree: free?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,16 @@ class User < ApplicationRecord
     subscriptions.comped.any?
   end
 
+  def free?
+    !active? && !comped?
+  end
+
+  def as_json(_)
+    {
+      isFree: free?
+    }
+  end
+
   private
 
   def notify_admin

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -1,59 +1,14 @@
-class WorkWeek
-  class InvalidDates < StandardError; end
-
-  attr_reader :work_days
-
-  def self.find_or_create_by(user:, year:, number:)
-    work_week = new(user, year, number)
-    work_week.find_or_create
-    work_week
-  rescue InvalidDates
-    # year and/or number failed to parse as valid date
-  end
-
-  def initialize(user, year, number)
-    @user = user
-    @year = year.to_i
-    @number = number.to_i
-    @work_days = []
-  end
-
+class WorkWeek < BaseWorkWeek
   def find_or_create
-    @work_days = dates.map do |date|
-      @user.work_days.find_or_create_by!(date: date)
+    self.work_days = dates.map do |date|
+      user.work_days.find_or_create_by!(date: date)
     end
-  end
-
-  def as_json(_)
-    {
-      dateSpan: date_span,
-      weekToDateIds: week_to_date_ids,
-      workDays: @work_days
-    }
-  end
-
-  def target_date
-    dates.first
   end
 
   private
 
   def week_to_date_ids
-    days = @work_days.select { |day| day.date <= Time.zone.today }
+    days = work_days.select { |day| day.date <= Time.zone.today }
     days.map(&:id)
-  end
-
-  def date_span
-    monday = dates.first
-    friday = dates.last
-    (monday..friday).to_s(:date_span)
-  end
-
-  def dates
-    raise InvalidDates unless @year.positive? && @number.positive?
-
-    @dates ||= (1..5).map { |day| Date.commercial(@year, @number, day) }
-  rescue StandardError
-    raise InvalidDates
   end
 end

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -7,6 +7,10 @@ class WorkWeek < BaseWorkWeek
 
   private
 
+  def disabled?
+    false
+  end
+
   def week_to_date_ids
     days = work_days.select { |day| day.date <= Time.zone.today }
     days.map(&:id)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,19 @@
 FactoryBot.define do
-  factory :user do
+  factory :user, aliases: [:free_user] do
     confirmed_at { Time.zone.now }
     sequence(:email) { |n| "user#{n}@example.com" }
     password { 'sh' * 9 }
+
+    factory :active_user do
+      after(:create) do |user|
+        FactoryBot.create(:subscription, user: user)
+      end
+    end
+
+    factory :comped_user do
+      after(:create) do |user|
+        FactoryBot.create(:comped_subscription, user: user)
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,57 @@ describe User do
     expect(user.valid?).to eq true
     expect(user.persisted?).to eq true
   end
+
+  describe '#can_view?' do
+    let(:active_user) { FactoryBot.create :active_user }
+    let(:comped_user) { FactoryBot.create :comped_user }
+    let(:free_user) { FactoryBot.create :free_user }
+
+    before { travel_to(Time.zone.local(2020, 1, 7)) }
+    after { travel_back }
+
+    context 'with this week' do
+      let(:year) { '2020' }
+      let(:number) { '02' }
+
+      it 'returns true for all users' do
+        expect(active_user.can_view?(year, number)).to eq true
+        expect(comped_user.can_view?(year, number)).to eq true
+        expect(free_user.can_view?(year, number)).to eq true
+      end
+    end
+
+    context 'with last week' do
+      let(:year) { '2020' }
+      let(:number) { '01' }
+
+      it 'returns true for all users' do
+        expect(active_user.can_view?(year, number)).to eq true
+        expect(comped_user.can_view?(year, number)).to eq true
+        expect(free_user.can_view?(year, number)).to eq true
+      end
+    end
+
+    context 'with next week' do
+      let(:year) { '2020' }
+      let(:number) { '03' }
+
+      it 'returns true for active and comped users but false for free users' do
+        expect(active_user.can_view?(year, number)).to eq true
+        expect(comped_user.can_view?(year, number)).to eq true
+        expect(free_user.can_view?(year, number)).to eq false
+      end
+    end
+
+    context 'with last year' do
+      let(:year) { '2019' }
+      let(:number) { '52' }
+
+      it 'returns true for active and comped users but false for free users' do
+        expect(active_user.can_view?(year, number)).to eq true
+        expect(comped_user.can_view?(year, number)).to eq true
+        expect(free_user.can_view?(year, number)).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/work_week_spec.rb
+++ b/spec/models/work_week_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe WorkWeek do
   describe '.find_or_create_by' do
-    let(:user) { FactoryBot.create :user }
+    let(:user) { FactoryBot.create :active_user }
 
     context 'with an invalid year' do
       it 'returns nil' do

--- a/spec/system/week_entry/free_user_sees_disabled_weeks_spec.rb
+++ b/spec/system/week_entry/free_user_sees_disabled_weeks_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'Free user sees disabled weeks', js: true do
+  before { travel_to(Time.zone.local(2020, 1, 7)) }
+  after { travel_back }
+
+  it 'shows disabled weeks for next week and week before last' do
+    last_year_path = work_week_path('2019-52')
+    last_week_path = work_week_path('2020-01')
+    this_week_path = work_week_path('2020-02')
+    next_week_path = work_week_path('2020-03')
+
+    user = FactoryBot.create(:user)
+    login_as(user, scope: :user)
+    visit this_week_path
+
+    within('main nav') do
+      click_link '>'
+      expect(page).to have_current_path(next_week_path)
+    end
+
+    expect(page).to have_css('.nullWorkWeek', count: 5)
+
+    within('main nav') do
+      click_link 'this week'
+      expect(page).to have_current_path(this_week_path)
+    end
+
+    expect(page).to have_no_css('.nullWorkWeek')
+
+    within('main nav') do
+      click_link '<'
+      expect(page).to have_current_path(last_week_path)
+    end
+
+    expect(page).to have_no_css('.nullWorkWeek')
+
+    within('main nav') do
+      click_link '<'
+      expect(page).to have_current_path(last_year_path)
+    end
+
+    expect(page).to have_css('.nullWorkWeek', count: 5)
+  end
+end

--- a/spec/system/week_entry/free_user_sees_nudge_spec.rb
+++ b/spec/system/week_entry/free_user_sees_nudge_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'Free user sees nudge', js: true do
+  before { travel_to(Time.zone.local(2020, 1, 7)) }
+  after { travel_back }
+
+  it 'always nudges to upgrade' do
+    last_year_path = work_week_path('2019-52')
+    last_week_path = work_week_path('2020-01')
+    this_week_path = work_week_path('2020-02')
+    next_week_path = work_week_path('2020-03')
+
+    user = FactoryBot.create(:user)
+    login_as(user, scope: :user)
+    visit this_week_path
+
+    within('main nav') do
+      click_link '>'
+      expect(page).to have_current_path(next_week_path)
+    end
+
+    expect(page).to have_css('p', text: 'upgrade your account')
+
+    within('main nav') do
+      click_link 'this week'
+      expect(page).to have_current_path(this_week_path)
+    end
+
+    expect(page).to have_css('p', text: 'upgrade your account')
+
+    within('main nav') do
+      click_link '<'
+      expect(page).to have_current_path(last_week_path)
+    end
+
+    expect(page).to have_css('p', text: 'upgrade your account')
+
+    within('main nav') do
+      click_link '<'
+      expect(page).to have_current_path(last_year_path)
+    end
+
+    expect(page).to have_css('p', text: 'upgrade your account')
+  end
+end


### PR DESCRIPTION
This PR introduces a couple new concepts for free users:

* nudge to upgrade on work week
* disabled work weeks

It looks like this:

<img width="1227" alt="Screen Shot 2020-12-28 at 9 46 49 AM" src="https://user-images.githubusercontent.com/79799/103226441-bff8bd80-48f1-11eb-8de9-4bbf53e46490.png">

Free users only have access to the current and previous weeks, so here I'm looking at the next week and seeing a nudge to upgrade and a disabled week.

## Wrong metaphor?

For the disabled work week, I'm using those blocks of color in place of the inputs and text. This technique is sometimes used to represent content that is in the process of being loaded onto the page - called a skeleton loading page. In this case, no amount of time is going to help load this content - it's not there because you haven't upgraded so it's probably the wrong UI idiom to use, but I couldn't think of anything better and this detail was blocking me from moving forward so I'm just going to ship it and if something better occurs to me I can always change it!