### PR TITLE
fix: Separate random wrappers from the main one

### DIFF
--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -63,12 +63,12 @@ body
     &::placeholder
       color: $middle-gray
 
-  .wrapper
+  #wrapper
     background-color: $bright-white
     margin: 0 auto
+    min-height: 400px
     padding: 20px
     width: 800px
-    min-height: 400px
 
     header
       nav

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,7 @@
     = javascript_include_tag 'application'
 
   %body
-    .wrapper
+    #wrapper
       %header
         %nav
           %a(href="/today") today


### PR DESCRIPTION
Oops, I broke the disabled week view:

<img width="1465" alt="Screen Shot 2020-12-28 at 3 52 47 PM" src="https://user-images.githubusercontent.com/79799/103245135-d1a78880-4924-11eb-82f9-c681f48d4389.png">

And I guess I didn't really notice that I was defining my wrapper styles way too loosely so this improves that by separating any old random wrapper from the main page wrapper.