### PR TITLE
feat: Handle card errors during payment flow

### DIFF
--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -157,6 +157,11 @@ body
       #upgrade_form_root
         margin: 0 auto
         width: 300px
+        .error
+          background-color: $bright-pink
+          margin: 0
+          padding: 20px
+          text-align: center
 
         .StripeElement
           border-bottom: 4px solid $middle-gray

--- a/app/controllers/upgrade_controller.rb
+++ b/app/controllers/upgrade_controller.rb
@@ -13,8 +13,9 @@ class UpgradeController < AuthenticatedController
 
   def create
     stripe_source_id = params[:stripe_source_id]
-    UserUpgrade.process(current_user, stripe_source_id)
-    render json: {}
+    upgrade = UserUpgrade.new(current_user, stripe_source_id)
+    upgrade.process
+    render json: upgrade
   end
 
   private

--- a/app/javascript/apps/UpgradeForm/components/InnerForm/InnerForm.tsx
+++ b/app/javascript/apps/UpgradeForm/components/InnerForm/InnerForm.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react"
 import { CardElement, useElements, useStripe } from "@stripe/react-stripe-js"
 import { UpgradeFormFetcher } from "../../UpgradeFormFetcher"
 
+const generalPaymentErrorMessage =
+  "Processing payment information is currently not working, please try again later."
+
 export interface InnerFormProps {
   email: string
   fetcher: UpgradeFormFetcher
@@ -24,13 +27,13 @@ export const InnerForm: React.FC<InnerFormProps> = (props) => {
 
   const handleUpgradeError = (error): void => {
     honeybadger.notify(error)
-    setErrorMessage(error.message)
+    setErrorMessage(generalPaymentErrorMessage)
   }
 
   const handleSourceResult = (result): void => {
     if (result.error) {
       honeybadger.notify(result)
-      setErrorMessage(result.error.message)
+      setErrorMessage(generalPaymentErrorMessage)
     } else {
       fetcher
         .createUpgrade(result.source.id)
@@ -41,7 +44,7 @@ export const InnerForm: React.FC<InnerFormProps> = (props) => {
 
   const handleSourceError = (error): void => {
     honeybadger.notify(error)
-    setErrorMessage(error)
+    setErrorMessage(generalPaymentErrorMessage)
   }
 
   const handleSubmit = (e): void => {

--- a/app/javascript/apps/UpgradeForm/components/InnerForm/InnerForm.tsx
+++ b/app/javascript/apps/UpgradeForm/components/InnerForm/InnerForm.tsx
@@ -5,40 +5,31 @@ import { UpgradeFormFetcher } from "../../UpgradeFormFetcher"
 export interface InnerFormProps {
   email: string
   fetcher: UpgradeFormFetcher
+  honeybadger: { notify: (any) => void }
 }
 
 export const InnerForm: React.FC<InnerFormProps> = (props) => {
-  const { email, fetcher } = props
+  const { email, honeybadger, fetcher } = props
   const stripe = useStripe()
   const elements = useElements()
   const [errorMessage, setErrorMessage] = useState("")
 
-  const handleUpgradeError = (error): void => {
-    // i should be sending this to Honeybadger!
-    console.log(error)
-    setErrorMessage(error.message)
-  }
-
   const handleUpgradeResult = (result): void => {
     if (result.error) {
-      // i should be sending this to Honeybadger!
-      console.log(result.error)
       setErrorMessage(result.error)
     } else {
       window.location.assign("/thanks")
     }
   }
 
-  const handleSourceError = (error): void => {
-    // i should be sending this to Honeybadger!
-    console.log(error)
-    setErrorMessage(error)
+  const handleUpgradeError = (error): void => {
+    honeybadger.notify(error)
+    setErrorMessage(error.message)
   }
 
   const handleSourceResult = (result): void => {
     if (result.error) {
-      // i should be sending this to Honeybadger!
-      console.log(result.error)
+      honeybadger.notify(result)
       setErrorMessage(result.error.message)
     } else {
       fetcher
@@ -46,6 +37,11 @@ export const InnerForm: React.FC<InnerFormProps> = (props) => {
         .then(handleUpgradeResult)
         .catch(handleUpgradeError)
     }
+  }
+
+  const handleSourceError = (error): void => {
+    honeybadger.notify(error)
+    setErrorMessage(error)
   }
 
   const handleSubmit = (e): void => {

--- a/app/javascript/apps/UpgradeForm/components/InnerForm/InnerForm.tsx
+++ b/app/javascript/apps/UpgradeForm/components/InnerForm/InnerForm.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import { CardElement, useElements, useStripe } from "@stripe/react-stripe-js"
 import { UpgradeFormFetcher } from "../../UpgradeFormFetcher"
 
@@ -11,24 +11,54 @@ export const InnerForm: React.FC<InnerFormProps> = (props) => {
   const { email, fetcher } = props
   const stripe = useStripe()
   const elements = useElements()
+  const [errorMessage, setErrorMessage] = useState("")
+
+  const handleUpgradeError = (error): void => {
+    // i should be sending this to Honeybadger!
+    console.log(error)
+    setErrorMessage(error.message)
+  }
+
+  const handleUpgradeResult = (result): void => {
+    if (result.error) {
+      // i should be sending this to Honeybadger!
+      console.log(result.error)
+      setErrorMessage(result.error)
+    } else {
+      window.location.assign("/thanks")
+    }
+  }
+
+  const handleSourceError = (error): void => {
+    // i should be sending this to Honeybadger!
+    console.log(error)
+    setErrorMessage(error)
+  }
 
   const handleSourceResult = (result): void => {
     if (result.error) {
+      // i should be sending this to Honeybadger!
       console.log(result.error)
+      setErrorMessage(result.error.message)
     } else {
-      fetcher.createUpgrade(result.source.id).then(() => {
-        window.location.assign("/thanks")
-      })
+      fetcher
+        .createUpgrade(result.source.id)
+        .then(handleUpgradeResult)
+        .catch(handleUpgradeError)
     }
   }
 
   const handleSubmit = (e): void => {
     e.preventDefault()
+    setErrorMessage("")
 
     const element = elements.getElement(CardElement)
     const sourceData = { type: "card", owner: { email } }
 
-    stripe.createSource(element, sourceData).then(handleSourceResult)
+    stripe
+      .createSource(element, sourceData)
+      .then(handleSourceResult)
+      .catch(handleSourceError)
   }
 
   const cardStyles = {
@@ -42,8 +72,11 @@ export const InnerForm: React.FC<InnerFormProps> = (props) => {
     hideIcon: true,
   }
 
+  const showError = errorMessage !== ""
+
   return (
     <form onSubmit={handleSubmit}>
+      {showError && <p className="error">{errorMessage}</p>}
       <CardElement options={cardElementOptions} />
       <input disabled={!stripe} type="submit" value="Pay" />
     </form>

--- a/app/javascript/packs/upgrade_form.tsx
+++ b/app/javascript/packs/upgrade_form.tsx
@@ -10,10 +10,12 @@ document.addEventListener("DOMContentLoaded", () => {
   const metaTag = document.querySelector("meta[name=csrf-token]")
   const token = metaTag && metaTag.getAttribute("content")
   const fetcher = new UpgradeFormFetcher(token)
+  const honeybadger = window["Honeybadger"]
 
   const props: UpgradeFormProps = {
     ...parsedProps,
     fetcher,
+    honeybadger,
   }
 
   ReactDOM.render(<UpgradeForm {...props} />, root)

--- a/app/models/user_upgrade.rb
+++ b/app/models/user_upgrade.rb
@@ -3,6 +3,8 @@ class UserUpgrade
     new(user, stripe_source_id).process
   end
 
+  attr_accessor :error
+
   def initialize(user, stripe_source_id)
     @user = user
     @stripe_source_id = stripe_source_id
@@ -13,6 +15,14 @@ class UserUpgrade
     update_user
     create_stripe_subscription
     subscribe_user
+  rescue Stripe::CardError => e
+    @error = e.error.message
+  end
+
+  def as_json(*_args)
+    {
+      error: error
+    }
   end
 
   private


### PR DESCRIPTION
This PR aims to take a step in the direction of better error handling during the payment flow. It's not perfect, but achieves my initial goals:

* surface basic errors like insufficient funds to users
* ensure fatal errors are being sent to Honeybadger
* show a general error message for fatal errors

It looks like this:

<img width="1055" alt="Screen Shot 2021-01-01 at 11 16 28 AM" src="https://user-images.githubusercontent.com/79799/103443284-0ec09300-4c23-11eb-9057-b42876907037.png">

## Where are the tests??

What I wish I could do is write some system tests that describe how various scenarios behave, but I've found it pretty challenging. My biggest hurdle is around the Stripe React library I'm using. There aren't great solutions for mocking that part out. I've read docs about how to do it in Jest, but booting up a real browser in a system test doesn't seem to play nicely with this part of my stack.

Still, I should have some unit tests around the React bits and a request spec or two around the upgrade endpoint. I plan to return to this but I wanted to get this shipped because IF there are errors, they could be stopping people from paying me and that's gotta be fixed!