### PR TITLE
feat: Implement basic responsive design

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,7 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
+ *= require site
+ *= require mobile
  *= require_self
  */

--- a/app/assets/stylesheets/mobile.css.sass
+++ b/app/assets/stylesheets/mobile.css.sass
@@ -1,0 +1,34 @@
+@media (max-width: 880px)
+  body
+    padding: 0 20px
+
+    #wrapper
+      margin: 0
+      padding: 20px 0
+      width: 100%
+
+      header
+        margin: 0 20px
+        nav
+          width: 100%
+      main
+        margin: 0 20px
+
+@media (max-width: 600px)
+  body
+    #wrapper
+      main
+        #week_entry_root
+          nav
+            flex-direction: column
+            margin-bottom: 30px
+            .left
+              h1, p
+                display: block
+              p
+                margin: -30px 0 0 0
+                padding: 0
+              text-align: center
+            .right
+              margin-top: 20px
+              text-align: center

--- a/app/assets/stylesheets/site.css.sass
+++ b/app/assets/stylesheets/site.css.sass
@@ -22,7 +22,7 @@ body
   color: $off-black
   font-family: $open-sans
   margin: 0
-  padding: 0
+  padding: 0 20px
 
   ::selection
     background-color: $middle-green


### PR DESCRIPTION
This PR adds a very basic responsive design for Forty - it looks like this:

<img width="612" alt="Screen Shot 2021-02-20 at 12 45 03 PM" src="https://user-images.githubusercontent.com/79799/108605410-900de980-7379-11eb-93a5-a4da8f9b9abb.png">
<img width="612" alt="Screen Shot 2021-02-20 at 12 45 16 PM" src="https://user-images.githubusercontent.com/79799/108605411-90a68000-7379-11eb-8558-c2bcd6525f71.png">

There's certainly more I can do here, but this at least gets the app useful at narrower screen sizes!